### PR TITLE
fix: widen negation-formula rule; drop README Status section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,3 @@ runner) against both intentionally AI-sounding and genuinely clean
 sample text, confirming the gate actually discriminates rather than
 rubber-stamping.
 
-## Status
-
-Early and standalone. Ships one fixed, general-audience rule set —
-no per-project voice profile yet, and no wiring into any other core
-(e.g. `landing-page`'s own copy skill keeps its existing prose
-self-check for now). Both are deliberate: prove the gate's rule set out
-here first before generalizing it or asking another core to depend on
-it.

--- a/workspace/scripts/check-copy/rules/tells.mjs
+++ b/workspace/scripts/check-copy/rules/tells.mjs
@@ -45,6 +45,7 @@ const RULE_OF_THREE = /\b(\w+),\s+(\w+),\s+(?:and|or)\s+(\w+)\b/gi;
 const TITLE_CASE_HEADER = /^#{1,6}\s+([A-Z][a-z]*(\s+[A-Z][a-z]*){2,})$/gm;
 const EM_DASH = /—/g;
 const NEGATION_FORMULA = /\b(?:is|are|it'?s)\s+not\s+(?:just|only)\s+[^.;]{2,60}[,—-]\s*(?:it'?s|they'?re)\s+/gi;
+const NEGATION_CONTRAST = /\b(\w+)\s+[^.;,]{2,60},\s+(?:and\s+)?not\s+\1\s+[^.;]{2,60}/gi;
 const HEDGE_STACK = /\b(could|may|might)\s+(potentially|possibly|eventually|ultimately)\b/gi;
 const COPULA_AVOIDANCE = /\b(serves as|stands as|marks a|functions as|represents a)\b/gi;
 
@@ -93,6 +94,7 @@ export function checkTells(text, { wordCount }) {
 
   for (const [re, rule, message] of [
     [NEGATION_FORMULA, 'tells/negation-formula', 'Negation formula ("it\'s not X, it\'s Y") — state the positive claim directly'],
+    [NEGATION_CONTRAST, 'tells/negation-formula', 'Negation contrast ("X because Y, not because Z") — state the positive claim directly'],
     [HEDGE_STACK, 'tells/hedge-stack', 'Stacked hedge ("could potentially", "may eventually") — pick one claim and state it'],
     [COPULA_AVOIDANCE, 'tells/copula-avoidance', 'Copula avoidance — plain "is/are" reads clearer than dressed-up substitutes'],
   ]) {

--- a/workspace/scripts/check-copy/test/check-copy.test.mjs
+++ b/workspace/scripts/check-copy/test/check-copy.test.mjs
@@ -12,6 +12,13 @@ test('fails on text stacked with banned AI-tell vocabulary and phrasing', async 
   assert.ok(report.violations.some((v) => v.rule === 'tells/hedge-stack'));
 });
 
+test('flags a because-not-because negation contrast', async () => {
+  const text = `A draft ships because a script checked it and exited 0, not because an agent read it and judged it clean.`;
+  const report = await checkCopy(text);
+  assert.equal(report.pass, false);
+  assert.ok(report.violations.some((v) => v.rule === 'tells/negation-formula'));
+});
+
 test('passes on plain, varied, concrete prose', async () => {
   const text = `Every handoff between Slack and your ticket tracker drops something. A decision made in chat never makes it into the ticket. We built a single feed that both tools write to. Comments sync both ways.`;
   const report = await checkCopy(text);


### PR DESCRIPTION
## Summary
- Widens `NEGATION_FORMULA` in `rules/tells.mjs` to also catch the "X because A, not because B" contrast family — the original regex only matched the "it's not just X — it's Y" surface form and missed this closely related AI-tell, found while dogfooding the core on a real article.
- Removes the README's Status section as this core moves from early/standalone to an official Hedgehog core.

## Test plan
- [x] `npm test` — 6/6 passing, including a new regression test for the negation-contrast pattern
- [x] Verified no false positive on the existing "passes on plain prose" control text
- [x] Manually confirmed the gate now fails (then passes after revision) on a real drafted article containing the missed pattern