### PR TITLE
docs: note the markdown-only keepsake override for bmad-brainstorming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog-core-copywriting",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Hedgehog's copywriting core: a mechanical checkCopy() gate against AI-tell and prose-quality contracts, the tells-detector and prose-quality skills that define them, and the copy-writer loop that drafts against the gate until it passes.",
   "type": "module",
   "scripts": {

--- a/skills/hedgehog-copywriting-loop/SKILL.md
+++ b/skills/hedgehog-copywriting-loop/SKILL.md
@@ -39,7 +39,13 @@ Add-ons decision on full-stack-app).
    day-to-day loop reads it live after this step mines it once. There
    is no reduced or copy-specific shelf: the full sequence runs even
    though `bmad-ux`'s design-handoff output isn't this core's primary
-   input — `bmad-prd` and `bmad-prfaq` are.
+   input — `bmad-prd` and `bmad-prfaq` are. `bmad-brainstorming`'s
+   Ideate-for-me mode defaults to auto-generating an HTML keepsake —
+   unwanted work on a core whose deliverables are plain prose. A project
+   that wants brainstorming sessions to stay markdown-only can set
+   `keepsake_format = "markdown-only"` in
+   `_bmad/custom/bmad-brainstorming.toml`; this core doesn't set it by
+   default, since some copywriting projects do want the visual keepsake.
 2. **Mine a draft brief** from `.hedgehog/BMAD/`: what's being written
    (the concrete piece — a landing page section, a product announcement,
    a UI microcopy string, docs prose), the audience, and the register to


### PR DESCRIPTION
## Summary
- `bmad-brainstorming`'s Ideate-for-me mode now supports `keepsake_format = "markdown-only"` (skyf0xx/hedgehog#386) to skip the auto-generated HTML keepsake.
- Copywriting is a natural fit — its deliverables are plain prose — so this points at the override where the shelf is invoked, rather than leaving it to be discovered mid-session when an unwanted HTML file starts generating.
- Doesn't set the override by default: some copywriting projects do want the visual keepsake, so this stays a pointer, not a mandate.

**Base branch note**: targets `fix/skip-bootstrap-handoff` (#4, not yet merged) — stacks 0.1.5 on that PR's 0.1.4.

Related: skyf0xx/hedgehog#386 (the mechanism itself lands in skyf0xx/hedgehog)

## Test plan
- [x] CI passes