### PR TITLE
fix: stop promising a bootstrap handoff that has no skill to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog-core-copywriting",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Hedgehog's copywriting core: a mechanical checkCopy() gate against AI-tell and prose-quality contracts, the tells-detector and prose-quality skills that define them, and the copy-writer loop that drafts against the gate until it passes.",
   "type": "module",
   "scripts": {

--- a/skills/hedgehog-copywriting-loop/SKILL.md
+++ b/skills/hedgehog-copywriting-loop/SKILL.md
@@ -15,7 +15,12 @@ process exiting 0 or 1 is.
 
 ## Planning intake (Phase 0, before any build layer)
 
-Run once, before `bootstrap` lands `scripts/check-copy/`. Opens with
+Run once. This core has no bootstrap step: `hedgehog init --copywriting`
+lands `scripts/check-copy/` and `core.yaml` together, as this package's
+`workspace/`, at install time — before planning intake ever starts. This
+is the one core `planner`'s generic Workflow step 9 does not hand off to
+`bootstrap` for; step 5 below runs `hedgehog plan` directly instead,
+since the core.yaml it needs is already on disk. Opens with
 `hedgehog-planning-intake`'s Phase 0 — the same vendored BMAD-METHOD
 shelf every other core runs, in the same full sequence, archived to the
 same `.hedgehog/BMAD/` layout. After that Phase 0 completes, this
@@ -54,13 +59,13 @@ Add-ons decision on full-stack-app).
    (`.hedgehog/BMAD/`), before writing anything to the build graph.
    State plainly what happens on confirmation: *"This locks in the
    brief, adds the `copy` intent to the build graph (`hedgehog intent
-   add`), compiles it into the two-layer chain (`hedgehog plan`),
-   commits (`chore(planning): copy brief`), and hands off to `bootstrap`
-   to land `scripts/check-copy/`. The draft layer starts once that
-   closes. Anything wrong or missing — say so now."* Wait for explicit
-   go-ahead — a revision here is just another mining pass against the
-   same BMAD archive, not a Correction Protocol entry, since nothing
-   downstream exists yet.
+   add`), compiles it into the two-layer chain (`hedgehog plan`), and
+   commits (`chore(planning): copy brief`). The draft layer starts right
+   after — this core's workspace is already installed, so there's no
+   bootstrap step to wait on. Anything wrong or missing — say so now."*
+   Wait for explicit go-ahead — a revision here is just another mining
+   pass against the same BMAD archive, not a Correction Protocol entry,
+   since nothing downstream exists yet.
 5. **Add the intent and compile the graph**: `hedgehog intent add --id
    copy --goal "<what's being written>" --outcome "<audience + register>"`
    — one call, no `--rule`/`--depends-on` needed; copywriting has no


### PR DESCRIPTION
## Summary
- `hedgehog-copywriting-loop`'s Confirm & Lock step described handing off to `bootstrap` after committing the brief, but this core ships no bootstrap skill — `init --copywriting` already lands `scripts/check-copy/` and `core.yaml` together (as this package's `workspace/`) at install time, before planning intake ever starts.
- Following the loop literally meant dispatching an agent to a skill file that doesn't exist for this core.
- Planning intake's own step 5 already runs `hedgehog plan` directly — this updates the loop's stated plan to match what it actually does, instead of promising a `bootstrap` handoff that goes nowhere.
- Companion change in `skyf0xx/hedgehog` (planner.md / bootstrap.md).

Recreates #4, which GitHub auto-closed when its base branch (#3's `fix/install-core-yaml`) was deleted on merge. Rebased cleanly onto `master` now that #3 is merged.

Fixes skyf0xx/hedgehog#385

## Test plan
- [x] CI passes