### PR TITLE
fix: add missing pnpm install step to scratch setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog-core-copywriting",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Hedgehog's copywriting core: a mechanical checkCopy() gate against AI-tell and prose-quality contracts, the tells-detector and prose-quality skills that define them, and the copy-writer loop that drafts against the gate until it passes.",
   "type": "module",
   "scripts": {

--- a/skills/hedgehog-copywriting-loop/SKILL.md
+++ b/skills/hedgehog-copywriting-loop/SKILL.md
@@ -46,7 +46,18 @@ there. Run these steps in order, before anything else in the session:
    `(copywriting installs to a scratch directory, never here — using
    <path>)` is the first line of output — as `$TMPDIR` for the rest of
    this session.
-4. **The invariant from here on**: every `hedgehog` command for the
+4. **Install the workspace's dependencies**, from inside `$TMPDIR`:
+   ```
+   (cd "$TMPDIR" && pnpm install)
+   ```
+   `init --copywriting` lands `scripts/check-copy/`'s `package.json` and
+   the workspace's lockfile but never runs the install itself — every
+   `check-copy` invocation below imports packages (`unified`, `retext-*`)
+   that don't exist on disk until this runs. Do this once, right after
+   capturing `$TMPDIR`, before Phase 0 or any `check-copy` call — running
+   it lazily on the first gate failure works too, but doing it here
+   means that failure never happens.
+5. **The invariant from here on**: every `hedgehog` command for the
    rest of this loop, and every file this loop writes (`.hedgehog/copy/`,
    the BMAD archive under `.hedgehog/BMAD/`), happens inside `$TMPDIR`,
    never `$ORIGDIR`. Every `hedgehog` invocation is wrapped as a


### PR DESCRIPTION
## Summary
- `init --copywriting` lands `scripts/check-copy/`'s `package.json` and the workspace's `pnpm-lock.yaml` at scratch-dir install time, but never runs `pnpm install` itself.
- `hedgehog-copywriting-loop`'s Phase -1 walked straight from capturing `$TMPDIR` into Phase 0 / the draft loop, with no install step described anywhere — an agent following the skill literally hits `ERR_MODULE_NOT_FOUND` on the very first `check-copy` invocation.
- Adds an explicit "install the workspace's dependencies" step to Phase -1, right after `$TMPDIR` is captured and before anything else runs.

Fixes skyf0xx/hedgehog#397

## Test plan
- [x] Read through the updated Phase -1 for internal consistency with the rest of the scratch-setup sequence.
- [x] No code paths changed — skill-file-only edit.