### PR TITLE
fix: ignore node_modules and node-compile-cache in scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog-core-copywriting",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Hedgehog's copywriting core: a mechanical checkCopy() gate against AI-tell and prose-quality contracts, the tells-detector and prose-quality skills that define them, and the copy-writer loop that drafts against the gate until it passes.",
   "type": "module",
   "scripts": {

--- a/workspace/gitignore.template
+++ b/workspace/gitignore.template
@@ -1,0 +1,7 @@
+node_modules
+node-compile-cache
+.DS_Store
+.hedgehog/graph-server.json
+.hedgehog/hedgehog.db
+.hedgehog/hedgehog.db-*
+.hedgehog/commit.lock


### PR DESCRIPTION
## Summary
- `workspace/` shipped no `.gitignore` at all, so a routine `pnpm install` in the scratch dir left every package under `node_modules/` and every entry under `node-compile-cache/` untracked.
- `hedgehog verify`'s scope check reads `git status`, so it picked up all of those as unscoped touched paths and blocked the `draft` task with a false-positive scope violation on the very first install + gate run.
- Adds `workspace/gitignore.template` (renamed to `.gitignore` by the installer at install time), following the same convention `landing-page` and `full-stack-app` already use.

Fixes skyf0xx/hedgehog#399

## Test plan
- [x] `npm pack --dry-run` confirms `workspace/gitignore.template` is included in the published tarball.
- [x] Simulated a fresh scratch install + `pnpm install` — `node_modules/` and `node-compile-cache/` no longer show as untracked in `git status`.