### PR TITLE
fix: stop weasel-word rule firing on ordinary connectives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog-core-copywriting",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Hedgehog's copywriting core: a mechanical checkCopy() gate against AI-tell and prose-quality contracts, the tells-detector and prose-quality skills that define them, and the copy-writer loop that drafts against the gate until it passes.",
   "type": "module",
   "scripts": {

--- a/workspace/scripts/check-copy/rules/prose.mjs
+++ b/workspace/scripts/check-copy/rules/prose.mjs
@@ -29,6 +29,22 @@ import { fleschKincaid } from 'flesch-kincaid';
 const READING_EASE_FLOOR = 50; // below this reads as hard for a general audience
 const GRADE_CEILING = 10; // above this reads as too technical/dense
 
+// retext-intensify's `weasel` rule fires off a merged fillers+hedges+weasels
+// word list (see retext-intensify/lib/index.js) with no way to select a
+// subset at match time — only an `ignore` list of exact phrases. A chunk of
+// that merged list (from the `weasels` package specifically) is ordinary
+// grammatical/connective vocabulary with no hedging signal on its own —
+// "that", "then", "so", "just", "also", "still", "about", "up", "down",
+// "well" carry the sentence in normal conversational prose and fire on
+// nearly every casual paragraph regardless of quality. Ignored here so the
+// rule keeps catching actual vagueness (arguably, reportedly, some, often,
+// probably, experts, and the rest of `weasels`/`hedges`/`fillers`) without
+// the noise floor drowning it out on a casual or humorous register.
+const WEASEL_IGNORE = [
+  'about', 'again', 'all', 'also', 'back', 'even', 'ever', 'far', 'just',
+  'like', 'over', 'own', 'so', 'still', 'that', 'then', 'up', 'well',
+];
+
 const SENTENCE_SPLIT = /[.!?]+[\s\n]+/;
 const NOMINALIZATION = /\b\w+(tion|ment|ance|ence)s?\b/gi;
 
@@ -94,7 +110,7 @@ export async function checkProse(text, { wordCount }) {
   const processor = unified()
     .use(retextEnglish)
     .use(retextPassive)
-    .use(retextIntensify)
+    .use(retextIntensify, { ignore: WEASEL_IGNORE })
     .use(retextRepeatedWords)
     .use(retextReadability, { age: 16, threshold: 4 })
     .use(retextStringify);

--- a/workspace/scripts/check-copy/test/check-copy.test.mjs
+++ b/workspace/scripts/check-copy/test/check-copy.test.mjs
@@ -44,3 +44,21 @@ test('flags low sentence-length variance (burstiness) on uniform sentences', asy
   const report = await checkCopy(text);
   assert.ok(report.violations.some((v) => v.rule === 'prose/low-burstiness'));
 });
+
+test('does not flag ordinary connective words as weasel words', async () => {
+  const text = `Then there's the whiskers. The cat still runs the household from that chair by the window. It just makes the smugness official.`;
+  const report = await checkCopy(text);
+  const weaselWords = report.violations
+    .filter((v) => v.rule === 'prose/weasel-word')
+    .map((v) => v.message);
+  assert.ok(
+    !weaselWords.some((m) => /`(that|Then|still|just|also|so|about)`/i.test(m)),
+    `expected no weasel-word hits on connective words, got: ${weaselWords.join(', ')}`,
+  );
+});
+
+test('still flags genuine hedging as a weasel word', async () => {
+  const text = `Some experts say the results are arguably promising, though the study reportedly used a small sample.`;
+  const report = await checkCopy(text);
+  assert.ok(report.violations.some((v) => v.rule === 'prose/weasel-word'));
+});


### PR DESCRIPTION
## Summary
- `retext-intensify`'s `weasel` rule fires off a merged `fillers`+`hedges`+`weasels` word list with no way to select a subset at match time — only an `ignore` list of exact phrases.
- Part of that merged list (`weasels` specifically) is plain grammatical/connective vocabulary — `that`, `then`, `so`, `just`, `also`, `still`, `about`, `up`, `down`, `well` — with no hedging signal on its own. On a casual or humorous register (a use case this core explicitly supports), it fired on nearly every sentence, drowning out real signal.
- Passes a narrow `ignore` list of those connectives into `retextIntensify`, kept small enough that genuine hedging (`arguably`, `reportedly`, `some`, `often`, `experts`, `probably`, ...) still fires.

Fixes skyf0xx/hedgehog#400

## Test plan
- [x] `npm test` — 8/8 passing, including two new regression tests: one confirming connective words no longer fire, one confirming genuine hedging still does.
- [x] Manually re-ran the check against the casual-register example from the issue — warning count on `prose/weasel-word` dropped to the words carrying actual vagueness.