### PR TITLE
fix: preempt agent dispatch-by-name failure at the delegate step

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog-core-copywriting",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Hedgehog's copywriting core: a mechanical checkCopy() gate against AI-tell and prose-quality contracts, the tells-detector and prose-quality skills that define them, and the copy-writer loop that drafts against the gate until it passes.",
   "type": "module",
   "scripts": {

--- a/skills/hedgehog-copywriting-loop/SKILL.md
+++ b/skills/hedgehog-copywriting-loop/SKILL.md
@@ -168,9 +168,19 @@ Add-ons decision on full-stack-app).
 
 1. **`hedgehog claim --owner copy-writer --count 1`** emits the task
    packet for the ready layer.
-2. **Delegate to `copy-writer`.** It reads the brief, drafts copy into
-   `.hedgehog/copy/final.md`, then runs the gate itself before
-   presenting anything:
+2. **Delegate to `copy-writer`.** This core's whole install is ephemeral
+   and same-session (Phase -1), so `copy-writer` was *just* written to
+   `.claude/agents/` moments ago — dispatch by name (`subagent_type:
+   copy-writer`) will reliably fail with "Agent type 'copy-writer' not
+   found" every single time, since this host only reads agent
+   registration once at session start, not mid-session. This isn't an
+   edge case to discover via a failed tool call: skip dispatch by name
+   entirely and read `.claude/agents/copy-writer.md` directly, then
+   follow it inline instead. (Root CLAUDE.md's "Delegating on this
+   host" note covers the same mechanism for every other core, where it
+   ordinarily *is* an edge case rather than the guaranteed path.) The
+   agent reads the brief, drafts copy into `.hedgehog/copy/final.md`,
+   then runs the gate itself before presenting anything:
    ```
    node scripts/check-copy/index.mjs .hedgehog/copy/final.md
    ```
@@ -237,8 +247,3 @@ Add-ons decision on full-stack-app).
   turns out wrong mid-draft is a Correction Protocol case — fix the
   brief at its source, re-run the draft layer, not patch around it in
   `final.md`.
-
-If a dispatch by name reports the agent as not found — expected right
-after `init`/`update` installed it this same session — see root
-CLAUDE.md's "Delegating on this host" note rather than treating it as
-fatal.


### PR DESCRIPTION
## Summary
- `copy-writer` is always installed mid-session by this core's ephemeral Phase -1 install — there's no persistent, pre-existing install to dispatch to, since the whole point of the scratch design is same-session, ephemeral install.
- Dispatch by name (`subagent_type: copy-writer`) therefore reliably fails with "Agent type 'copy-writer' not found" on literally the first delegation attempt of every session, since this host only reads agent registration once, at session start.
- The workaround was already documented (read `.claude/agents/copy-writer.md` directly), but only as a footnote at the very end of the skill file — step 2 said "delegate to `copy-writer`" with no warning the dispatch itself was about to fail, so an agent following the loop had to discover the failure via a failed tool call and then cross-reference the footnote.
- Moves the caveat inline to step 2, at the point of delegation, so the failed dispatch attempt is skipped entirely instead of discovered after the fact.

Fixes skyf0xx/hedgehog#398

## Test plan
- [x] Read through the updated step 2 for consistency with root CLAUDE.md's "Delegating on this host" note, which this cross-references rather than restates.
- [x] No code paths changed — skill-file-only edit.