### PR TITLE
feat: add ad, landing-page, direct-response, and tweet copy types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+package-lock.json

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,9 @@
 # Architecture
 
 Hedgehog's copywriting core: a mechanical `checkCopy()` gate against
-AI-tell and prose-quality contracts, the skills that document what it
-checks, and the loop that drafts copy against it until it passes.
+AI-tell, prose-quality, and per-format contracts, the skills that
+document what it checks, and the loop that drafts copy against it until
+it passes.
 
 The gate is real code — `retext`, `write-good`, and `flesch`/
 `flesch-kincaid` under the hood — not an agent's own read of its draft.
@@ -14,22 +15,43 @@ A piece of copy ships because a script exited 0, the same trust model
 - `workspace/scripts/check-copy/` — the gate, copied to
   `scripts/check-copy/` at the root of every project this core installs
   into. `index.mjs` is the CLI entry
-  (`node scripts/check-copy/index.mjs <file>`), `rules/tells.mjs` is
-  the AI-tell rule set (banned vocabulary, negation formulas, hedge
-  stacks, structural density checks), `rules/prose.mjs` is the
-  prose-quality rule set (passive voice, weasel words, readability,
-  sentence-length variance, nominalization density), and `report.mjs`
-  is the zod-validated output shape every rule reports through.
+  (`node scripts/check-copy/index.mjs <file> [--format <type>]`),
+  `rules/tells.mjs` is the AI-tell rule set (banned vocabulary,
+  negation formulas, hedge stacks, structural density checks),
+  `rules/prose.mjs` is the prose-quality rule set (passive voice, weasel
+  words, readability, sentence-length variance, nominalization density),
+  and `report.mjs` is the zod-validated output shape every rule reports
+  through.
+- `workspace/scripts/check-copy/rules/formats/` — the per-format
+  contracts, one module per copy type (`ad.mjs`, `landing-page.mjs`,
+  `direct-response.mjs`, `tweet.mjs`), with `shared.mjs` holding the
+  section parser, X's character-counting rule, and the compliance-claim
+  list, and `index.mjs` holding the registry `--format` resolves against.
+  These check what the prose rules structurally cannot: whether copy
+  obeys the medium it ships into. A 446-character post and a Meta ad
+  headline at double the platform limit are both defects that no rule
+  about sentences can see. A format module only ever adds to the
+  universal pair and never relaxes it.
 - `workspace/core.yaml` — the two-layer chain (`brief` → `draft`) a
   Hedgehog install compiles into its build graph, copied to the root of
   every project this core installs into alongside `scripts/check-copy/`.
+  The `draft` layer's verify reads the copy type from the brief's
+  `type:` field and passes it to the gate as `--format`, falling back to
+  `prose` when the brief names none.
 - `agents/copy-writer.md` — drafts copy and iterates it against the
   gate until it passes or a real conflict with the brief surfaces.
 - `skills/hedgehog-copywriting-loop/` — the operating loop: brief
   intake, then the draft/checkCopy()/revise cycle.
 - `skills/tells-detector/` and `skills/prose-quality/` — reference for
-  what each rule actually checks and why, read before revising against
-  a violation rather than in place of running the script.
+  what each universal rule actually checks and why, read before revising
+  against a violation rather than in place of running the script.
+- `skills/ad-copy/`, `skills/landing-page-copy/`,
+  `skills/direct-response-copy/`, and `skills/tweet-copy/` — one per
+  format contract, documenting that format's `format/*` rules alongside
+  the craft guidance for writing into it. The three marketing skills are
+  adapted from Rob Palmer's copywriting skills under CC BY 4.0;
+  `tweet-copy` is adapted from Sergey Bulaev's `x-post-writer` under
+  the MIT licence. Each carries its attribution.
 - `CLAUDE.core.md` — fills a Hedgehog project's root `CLAUDE.md`
   `{{CORE_SECTION}}` placeholder for this core.
 - `hedgehog-core.yaml` — this package's manifest.
@@ -42,10 +64,15 @@ this core installed into (against `scripts/check-copy/`):
 ```
 cd scripts/check-copy && npm install   # or workspace/scripts/check-copy in this repo
 node index.mjs path/to/draft.md
+node index.mjs path/to/post.md --format tweet
+node index.mjs path/to/post.md --format tweet --premium
 ```
 
 Exits 0 with `pass: true` in the JSON report when no error-severity
-violation fired; exits 1 with `pass: false` otherwise.
+violation fired; exits 1 with `pass: false` otherwise. `--format` takes
+`prose` (the default), `ad`, `landing-page`, `direct-response`, or
+`tweet`, and an unrecognised value exits 2 rather than silently falling
+back. The report's `metrics.format` names the contract that ran.
 
 ## Tests
 
@@ -56,4 +83,7 @@ npm test
 Runs `workspace/scripts/check-copy`'s test suite (Node's built-in test
 runner) against both intentionally AI-sounding and genuinely clean
 sample text, confirming the gate actually discriminates rather than
-rubber-stamping.
+rubber-stamping. `test/formats.test.mjs` does the same per format, and
+pins the hole the format contracts were written to close: the
+over-limit post and the non-compliant ad it opens with both passed the
+universal contract with zero errors before those rules existed.

--- a/CLAUDE.core.md
+++ b/CLAUDE.core.md
@@ -25,12 +25,32 @@ contract.
   voice, weasel words, readability score, sentence-length variance,
   nominalization density.
 
+The two above are universal and run against every draft. The four below
+document the per-format contracts (`format/*`), each selected by the
+brief's `type:` field. Read the one matching the copy type before
+drafting, since a format contract shapes the draft rather than only
+grading it afterwards.
+
+- **`ad-copy`** (`type: ad`) — Meta ad copy: the three fields and their
+  character limits, the 125-character "See more" fold, and the
+  compliance claims that get an ad account suspended.
+- **`landing-page-copy`** (`type: landing-page`) — short-form bridge and
+  pre-sell pages: the three-paragraph framework, message match from the
+  ad, and mobile-first formatting.
+- **`direct-response-copy`** (`type: direct-response`) — long-form sales
+  copy, VSLs, and email: headlines, open loops, the slippery slide, and
+  the classic frameworks behind them.
+- **`tweet-copy`** (`type: tweet`) — a single post on X: the hook
+  formulas, the 280-character limit and how X actually counts it, and
+  the engagement patterns that suppress reach.
+
 ### The agent
 
-`copy-writer` runs the `draft` layer: reads the locked brief, drafts
-into `.hedgehog/copy/final.md`, and iterates against the gate until it
-passes or a real conflict surfaces. It never presents a draft that
-hasn't actually been run through `scripts/check-copy`.
+`copy-writer` runs the `draft` layer: reads the locked brief and its
+`type:`, drafts into `.hedgehog/copy/final.md`, and iterates against the
+gate until it passes or a real conflict surfaces. It never presents a
+draft that hasn't actually been run through `scripts/check-copy`, and
+never drops or switches `--format` to get a passing report.
 
 ## The constants (do not deviate)
 
@@ -40,20 +60,31 @@ hasn't actually been run through `scripts/check-copy`.
 whether a draft is done:
 
 ```
-node scripts/check-copy/index.mjs <file>
+node scripts/check-copy/index.mjs <file> [--format <type>] [--premium]
 ```
 
 Exits 0 and reports `pass: true` when no error-severity violation
-fired; exits 1 with `pass: false` otherwise. Built on `retext` (passive
+fired; exits 1 with `pass: false` otherwise.
+
+`--format` is one of `prose` (the default), `ad`, `landing-page`,
+`direct-response`, or `tweet`, and comes from the brief's `type:` field.
+The AI-tell and prose contracts run either way; the format contract adds
+what those rules cannot see, which is whether the copy obeys the medium
+it ships into. A 446-character post is a defect no prose rule can catch,
+because nothing about its sentences is wrong. `metrics.format` in the
+report names the contract that ran. Built on `retext` (passive
 voice, weasel words, repeated words, readability), `write-good` (wordy
 phrases, clichés), `flesch`/`flesch-kincaid` (document-level readability
 scores), and a custom AI-tell rule set (`scripts/check-copy/rules/tells.mjs`)
 — not hand-rolled grammar or syllable-counting logic. `zod`
 (`scripts/check-copy/report.mjs`) validates the report's shape.
 
-This core ships one fixed rule set — general-audience defaults (Flesch
-Reading Ease floor of 50, Flesch-Kincaid grade ceiling of 10) — not a
-per-project voice profile. A genuine mismatch (a technical register
+This core ships one fixed rule set per format — general-audience
+defaults (Flesch Reading Ease floor of 50, Flesch-Kincaid grade ceiling
+of 10) plus the selected format's own contract, not a per-project voice
+profile. A format contract only ever adds to the universal pair and
+never relaxes it, so no copy type is licensed to sound more like an LLM
+because of where it ships. A genuine mismatch (a technical register
 that needs jargon the gate flags, a document that must stay dense) is a
 signal to extend the contract deliberately, not to work around a
 warning or error silently on a per-draft basis.
@@ -68,10 +99,12 @@ started in.
 
 ```text
 scripts/check-copy/       the gate: index.mjs (CLI entry), rules/tells.mjs,
-                           rules/prose.mjs, report.mjs (zod-validated output shape)
+                           rules/prose.mjs, rules/formats/ (the per-type
+                           contracts), report.mjs (zod-validated output shape)
 .hedgehog/
   copy/
-    00-brief.md            what's being written, for whom, in what register
+    00-brief.md            what's being written, its type, for whom, in
+                             what register
     final.md                the draft under iteration, gated by check-copy
   hedgehog.db               the build graph — the copy intent, its two
                              compiled layers, verifications, committed to git
@@ -89,5 +122,6 @@ by anything in the loop.
 
 **A pass is a script exit code, not a sentence.** No copy ships on the
 strength of "this reads clean" — it ships because
-`node scripts/check-copy/index.mjs` said so, checked at both the
-informal drafting loop and again at `hedgehog verify`.
+`node scripts/check-copy/index.mjs` said so, under the format its brief
+named, checked at both the informal drafting loop and again at
+`hedgehog verify`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI writing tools grade their own homework. This one doesn't.
 
-Ask for an article, email, or landing page. It drafts the copy, runs it through a quality gate, and hands you a clean file.
+Ask for an article, a Meta ad, a landing page, a sales page, or a post for X. It drafts the copy, runs it through a quality gate, and hands you a clean file.
 
 ## Get started
 
@@ -18,10 +18,19 @@ Answer a short set of questions, and the finished piece lands in your current fo
 ask -> draft -> gate check -> clean file
 ```
 
-The gate checks:
+The gate checks every draft for:
 
 - **AI-sounding language.** Tell-tale phrases, hedge stacks, patterns that read as machine-written.
 - **Clean prose.** Readability, sentence variety, passive voice.
+
+And it checks the rules of the place the copy is going:
+
+| Writing a... | It also checks |
+| --- | --- |
+| Meta ad | Character limits per field, a real call to action, and claims that get an ad account suspended |
+| Landing page | A headline and a call to action, proof, and paragraphs short enough to read on a phone |
+| Sales page or email | A call to action, at least one specific number, and no filler benefit claims |
+| Post for X | The 280-character limit counted the way X counts it, hashtags, and engagement bait |
 
 A draft that fails gets revised and checked again, every time.
 
@@ -30,6 +39,8 @@ A draft that fails gets revised and checked again, every time.
 The checks are code. A script runs on every draft and decides pass or fail, so the model that wrote the piece never grades its own work.
 
 That's why a piece that passes here reads clean by an outside measure instead of the writer's own opinion.
+
+It also catches what reading alone misses. A post can be well written and still be 60% over the character limit. An ad can be well written and still promise something that gets the account banned. Those are the failures a script sees and a careful reader does not.
 
 ---
 

--- a/agents/copy-writer.md
+++ b/agents/copy-writer.md
@@ -1,6 +1,6 @@
 ---
 name: copy-writer
-description: Use for the draft layer of the copywriting core's loop — drafts copy from the locked brief and iterates it against scripts/check-copy's mechanical AI-tell and prose-quality gate until it passes, rather than presenting on the agent's own read of the draft.
+description: Use for the draft layer of the copywriting core's loop — drafts copy from the locked brief and iterates it against scripts/check-copy's mechanical AI-tell, prose-quality, and per-format gate until it passes, rather than presenting on the agent's own read of the draft.
 model: sonnet
 color: pink
 tools: Read, Glob, Grep, Edit, Write, Bash
@@ -18,20 +18,42 @@ what register. Read-only once this layer starts; a brief that turns
 out wrong is a Correction Protocol case handled at its source, not
 patched around here.
 
+The brief's `type:` field names the copy type, and decides which format
+contract the gate runs alongside the universal ones:
+
+| `type:` | Format contract | Reference skill |
+| --- | --- | --- |
+| `prose` (default) | none beyond the universal pair | — |
+| `ad` | Meta field limits, CTA, compliance claims | `ad-copy` |
+| `landing-page` | headline, CTA, proof, mobile paragraph length | `landing-page-copy` |
+| `direct-response` | CTA, specificity, vague-benefit, proof | `direct-response-copy` |
+| `tweet` | 280-character limit, hashtags, engagement bait | `tweet-copy` |
+
+A brief with no `type:` is `prose`. Never pick a format the brief did
+not name: if the brief says `tweet` and the request reads like a landing
+page, that mismatch goes back to the user, since the brief is read-only
+here.
+
 ## Workflow
 
 1. Read the brief. If it names source material (a repo, README, product
-   notes, past chat context), read that too.
+   notes, past chat context), read that too. Read the reference skill
+   for the brief's copy type before drafting, since the format contract
+   shapes the draft rather than merely grading it afterwards.
 2. Draft into `.hedgehog/copy/final.md`.
-3. Run the gate:
+3. Run the gate, passing the brief's `type:` as `--format` (omit the
+   flag, or pass `prose`, when the brief names no type):
    ```
-   node scripts/check-copy/index.mjs .hedgehog/copy/final.md
+   node scripts/check-copy/index.mjs .hedgehog/copy/final.md --format <type>
    ```
+   On `type: tweet`, add `--premium` only where the brief says the
+   account is on X Premium; without it the 280-character limit applies.
 4. Read the JSON report.
    - `pass: false` — at least one error-severity violation. Fix the
      actual thing each violation names (see `tells-detector` and
-     `prose-quality` for what each rule means and why), not just
-     enough wording to dodge the specific match. Re-run.
+     `prose-quality` for the universal rules, and the reference skill
+     for this copy type for the `format/*` ones), not just enough
+     wording to dodge the specific match. Re-run.
    - `pass: true`, warnings present — weigh each warning against the
      brief's register. Revise what's worth revising; a warning doesn't
      block, so don't chase every one to zero at the cost of a sentence
@@ -55,14 +77,19 @@ patched around here.
 - Never invent a voice-profile exception ad hoc. The gate's default
   thresholds are this core's one fixed contract; a real mismatch is
   reported to the user, not bypassed per-draft.
+- Never drop or switch `--format` to get a passing report. Running a
+  tweet through the `prose` contract hides the character limit rather
+  than meeting it, which is the exact failure the format rules exist to
+  catch.
 - Never fabricate a proof point, statistic, or named source not present
   in the brief or its source material.
 
 ## Self-test
 
 - `scripts/check-copy/index.mjs` was actually run against the final
-  draft, and its JSON output — not a paraphrase of it — is what's being
-  reported.
+  draft, with the `--format` matching the brief's `type:`, and its JSON
+  output (not a paraphrase of it) is what's being reported. The
+  report's `metrics.format` confirms which contract ran.
 - Every error-severity violation from the last run is resolved; every
   warning was weighed, not reflexively silenced.
 - The draft matches the brief's named register and audience.

--- a/hedgehog-core.yaml
+++ b/hedgehog-core.yaml
@@ -5,4 +5,13 @@ engine: "^6.0.0"
 workspace: workspace/
 template: CLAUDE.core.md
 agents: [copy-writer]
-skills: [hedgehog-copywriting-loop, tells-detector, prose-quality]
+skills:
+  - hedgehog-copywriting-loop
+  # The universal contracts, run against every draft.
+  - tells-detector
+  - prose-quality
+  # The per-format contracts, selected by the brief's `type:` field.
+  - ad-copy
+  - landing-page-copy
+  - direct-response-copy
+  - tweet-copy

--- a/skills/ad-copy/SKILL.md
+++ b/skills/ad-copy/SKILL.md
@@ -1,0 +1,455 @@
+---
+name: ad-copy
+description: Reference for what scripts/check-copy's Meta ad format contract actually flags and why: the three-field structure, Meta's hard character limits, the 125-character "See more" fold, button-label headlines, missing CTAs, and the unqualified claims that get ad accounts suspended. Read this to understand a `format/*` violation on `--format ad` before revising against it, and for the craft of writing toward the contract, not to hand-grade a draft in place of running the script.
+---
+
+# Ad copy
+
+> Adapted from the `ad-copy` skill by Rob Palmer
+> (https://github.com/robpalmer99/claude-code-copywriting-skills),
+> used under CC BY 4.0.
+
+`scripts/check-copy/rules/formats/ad.mjs` is the actual gate for this
+format, and this skill explains what it checks and why. Invoke it as:
+
+```
+node scripts/check-copy/index.mjs <file> --format ad
+```
+
+The universal contracts (`tells-detector`'s `tells/*` rules and
+`prose-quality`'s `prose/*` rules) always run underneath. The ad module
+only ever adds to them. No copy type is licensed to sound more like an
+LLM because of where it ships, so an ad still has to clear the same
+banned-vocabulary and readability bar as an essay. Never substitute a
+manual read of this list for actually running the script; the whole
+point of this core is that the check is mechanical.
+
+## The input shape the gate expects
+
+A draft names its fields as markdown sections:
+
+```
+## Primary text
+...
+
+## Headline
+...
+
+## Description
+...
+```
+
+The section lookup accepts aliases, so `## Body` or `## Ad copy`
+resolves to primary text, `## Title` to headline, and
+`## Link description` to description. A draft with no sections at all
+is read as primary text alone, which means a one-field hook brainstorm
+still gets checked rather than passing silently. As soon as the draft
+has any sections, though, one of them has to be primary text.
+
+## What the gate checks
+
+- **`format/missing-field`** (error). The draft has sections but none
+  of them is primary text. Primary text carries the sell; a headline
+  and description with nothing above the creative is not an ad.
+- **`format/primary-text-length`** (error). Primary text over Meta's
+  2200-character maximum. The platform rejects past this, so it is a
+  hard defect rather than a style opinion.
+- **`format/weak-hook`** (warning). Primary text runs past the
+  125-character "See more" fold mid-thought. The rule only fires when
+  the visible slice fails to end cleanly: it passes if the first 125
+  characters close on `.`, `!`, `?`, or `:`, or if a line break falls
+  inside them. A hook cut off mid-sentence with no open loop shows the
+  reader a truncated fragment, and the reader scrolls.
+- **`format/missing-cta`** (error). No call to action in the primary
+  text. The check looks for an imperative verb (click, tap, get, grab,
+  start, try, book, claim, download, watch, see, join, order, shop,
+  learn), or a friction-reducing offer word in the description (free,
+  no credit card, instant). An ad with neither is a post.
+- **`format/headline-length`** fires twice over. Past Meta's
+  40-character maximum it is an **error**, because the platform rejects
+  the ad. Past 27 characters it is a **warning**, because mobile
+  truncates around there and the tail goes unread. Display truncation
+  is a tradeoff a writer can knowingly accept; platform rejection is
+  not.
+- **`format/weak-headline`** (error). The headline is a button label
+  rather than a second hook. The list is exact: "learn more", "click
+  here", "check this out", "find out more", "read more", "see more",
+  "shop now", "sign up", "get started", "discover more", "act now".
+  Meta already renders a CTA button; spending the headline slot
+  repeating it throws away the ad's second-best piece of real estate.
+- **`format/description-length`** (error). Description over Meta's
+  30-character maximum. Platform rejection again.
+- **`format/unqualified-claim`** (error, one per match). Guaranteed
+  outcomes ("guaranteed you'll", "guarantee to"), absolute risk-free
+  promises ("100% risk-free", "completely guaranteed"), "zero risk",
+  "results are typical", make-money-fast, get-rich-quick, "no effort
+  required", cure claims ("cures your"), and specific weight-loss
+  claims ("lose 30 lbs"). These are errors rather than warnings for a
+  blunt commercial reason: ad networks suspend accounts over them. A
+  rejected ad costs an afternoon. A suspended ad account costs the
+  channel, and Meta's appeal process is slow and frequently
+  unsuccessful. The fix is to qualify the claim (name the study, name
+  the timeframe, name the person it happened to) or cut it. This check
+  runs across the whole draft, including the headline and the
+  description.
+- **`format/missing-proof`** (warning). Primary text over 200
+  characters with no digit anywhere in it and no attribution verb
+  (said, says, told, according to). A number, a named source, or a
+  timeframe all satisfy it. Past 200 characters the ad has stopped
+  being a hook and started making an argument, and an argument with no
+  proof reads as an assertion.
+
+## The three fields and what each one does
+
+Meta renders three text fields around the creative, and each has a
+different job.
+
+**Primary text** sits above the creative, capped at 2200 characters,
+with roughly the first 125 visible before "See more". This is the main
+sell. Treat those first 125 characters as a headline in their own
+right.
+
+**Headline** sits below the creative, capped at 40 characters, with
+mobile truncating around 27. Use it for a second hook carrying a
+specific benefit. Compare "Learn more" against "The 7-second
+morning fix", "Why diets fail after 40", or "23 lbs in 8 weeks". The
+last three each promise something particular and open a question.
+
+**Description** sits below the headline, capped at 30 characters, and
+is often hidden entirely on mobile, so load-bearing information does
+not belong in it. Use it for friction reduction: "Free shipping", "No credit card
+needed", "2-minute read".
+
+Placement changes what survives. In Feed the primary text shows with
+125 visible and the headline shows. In Stories and Reels the primary
+text is truncated heavily and the headline may not appear at all. In
+the right column the primary text is hidden and only a truncated
+headline shows. Write so the ad still works when the fields you cannot
+count on disappear.
+
+## Structuring primary text for the fold
+
+For most impressions the first 125 characters are the entire ad. What
+follows is read only by people who chose to expand, and that expansion
+click is itself a micro-conversion: anyone who taps "See more" is
+already engaged.
+
+```
+[Hook: first 125 characters. Land a complete thought or an open loop.]
+                                           <- the "See more" break
+[Expand: agitate the problem, tease the mechanism, drop proof.]
+[CTA: name the next step.]
+```
+
+The gate's `format/weak-hook` warning encodes the failure mode. A
+sentence sliced through its middle at character 125 gives the reader a
+fragment with no reason to expand. Two ways to satisfy it: end a
+sentence before the fold, or put a line break inside the first 125
+characters so the visible portion reads as a deliberate unit. Line
+breaks also buy white space in feed, which helps readability on a
+phone. One or two emoji can break the visual pattern; more than that
+reads as noise.
+
+## Schwartz's five levels of awareness
+
+Eugene Schwartz's model decides the headline, the copy length, the
+angle, and where the click should land. The rule underneath is that
+the less the reader already knows, the longer and more indirect the
+copy has to be.
+
+| Level | Lead with | Length | Send to |
+|---|---|---|---|
+| Unaware | Identity or emotion, not the problem | Long, educational | Advertorial |
+| Problem-aware | Name the pain vividly, tease a mechanism | Medium-long | Long-form sales page or advertorial |
+| Solution-aware | Differentiate your mechanism | Medium | Sales page or long product page |
+| Product-aware | Handle objections, add proof | Short-medium | Product page |
+| Most-aware | Lead with the deal | Short | Checkout or offer page |
+
+An unaware reader has no idea a problem exists, so an ad that opens
+with the product is answering a question they have not asked. A
+most-aware reader already knows the product and is waiting on a reason
+to act now, so an ad that opens with education wastes their patience.
+Both failures look identical in the report (a clean pass) and different
+in the results, which is why the gate cannot catch them and you have
+to.
+
+## Funnel position and the sell-the-click decision
+
+Funnel position is a separate axis from awareness. Cold traffic knows
+nothing about you, so lead with problem or curiosity and expect to
+educate. Warm traffic has seen you before, so go more direct and lean
+on the mechanism. Retargeting has already visited the page, so handle
+objections, bring social proof, and add urgency.
+
+The larger strategic call is what the ad itself is for.
+
+**Sell the click.** A short caption, a curiosity-driven image or video,
+minimal information revealed. The ad's only job is the click; the page
+it lands on does the selling. Best for unaware and problem-aware
+audiences, products that need explaining, and high-ticket offers.
+
+**Sell the solution.** A longer video with education, visual demos, and
+proof. The ad does most of the selling and the page only has to close.
+Best for solution-aware audiences and up, simple or visual products,
+and lower price points.
+
+One rule connects the two: showing the product in the ad makes the
+viewer product-aware. Sending a product-aware viewer to a page written
+for someone who has never heard of the product wastes the awareness you
+just created. Send them to a product or offer page instead. Large
+advertisers commonly run both strategies at once against different
+audiences.
+
+Where the click lands is a separate contract with its own gate. See
+`landing-page-copy` for short-form pages and `direct-response-copy` for
+long-form sales pages.
+
+## Hooks
+
+The hook is the biggest single lever in ad performance, which is why it
+is also the thing to test most.
+
+| Type | Shape | Use when |
+|---|---|---|
+| Curiosity | "There's a reason your doctor won't mention this" | Cold, unaware |
+| Contrarian | "Everything you've been told about X is wrong" | Problem-aware, skeptical |
+| Social proof | "Over 47,000 women have tried this 30-second trick" | Solution-aware and up |
+| Story | "Last March I was 40 lbs overweight and my doctor said" | Cold, emotional markets |
+| Demographic callout | "Attention men over 50 who..." | Cold, tightly targeted |
+| Result | "I lost 23 lbs in 8 weeks without giving up pizza" | Warm, retargeting |
+| Pattern interrupt | "Stop scrolling. This actually matters." | Cold, saturated markets |
+| Fascinating fact | "Your liver processes 500+ chemicals before breakfast" | Unaware, education-first |
+
+Hook rules:
+
+- The first line of text (or the first three seconds of video) has to
+  arrest attention on its own.
+- Keep the curiosity fragmented and open-ended. A complete fascination
+  closes the loop and removes the reason to click.
+- Be specific. "47,312 women" outperforms "thousands of women" because
+  the odd number reads as counted rather than claimed.
+- Hint at what the reader will discover without revealing it.
+- Say what it is not to intensify what it is. Rule out a diet, then a
+  pill, then exercise, and the reader leans in on what is left.
+- A winning hook can run for months. Keep testing new ones against it.
+
+### The curiosity toolbox
+
+**Open loops** create an information gap that only a click closes.
+"I tested 47 headlines. One pattern beat everything else by 3x."
+The reader now wants to know which pattern.
+
+**Tangible curiosity** makes the gap concrete. "Discover the secret to
+weight loss" is vague enough to ignore. "Discover the 7-second morning
+trick that targets the fat cells your body forgot about" names a
+duration, a time of day, and a mechanism, so there is something
+specific to be curious about.
+
+**Bucket brigades** are transitions that pull the reader forward: "But
+here's the thing...", "Here's what I discovered...", "This is where it
+gets interesting...", "Wait, it gets better...", "Now here's what
+nobody tells you...". Use two or three per ad. Ending every paragraph
+on a bridge gets tiresome fast.
+
+### Intrigue intensifiers
+
+- **Say what it is not.** "It isn't a diet. It isn't a supplement.
+  It isn't exercise. It isn't willpower."
+- **Say where it is not.** "You won't find it in any store, any
+  pharmacy, any website."
+- **Drop a specific hint.** "It's 150 million years old." "It's smaller
+  than a nickel." "It grows only above 12,000 feet in the Andes."
+- **Anchor to authority.** A named institution, a named study, a named
+  publication. Vague attribution of the "some researchers reckon" kind
+  is banned outright by `tells/banned-phrase`, so name the source or
+  drop the claim.
+
+The mechanism itself is what makes the solution different from
+everything the reader already tried. Strong mechanisms are credible
+(backed by the most authoritative source available), rare or hard to
+find, small and specific (a "7-second trick" beats a "20-minute
+routine"), and low-effort to apply.
+
+## The WHY / WHAT / HOW structure
+
+A fill-in-the-blank spine for primary text, from Alen Sultanic.
+
+**WHY (the problem).** Open with curiosity or a contrarian claim, name
+the problem, agitate it.
+
+> "Why does ____ matter more than ____ after ____?"
+> "Experts are calling it the '____'. But that's not what it is."
+> "It hits from all sides: ____ stress, ____ stress, ____ stress."
+
+**WHAT (the mechanism).** Pivot to how the solution works, and tease it
+without giving it away.
+
+> "There's another way, one that focuses on ____ instead of ____."
+> "Using this approach, 12,000 people have ____ in under ____."
+
+**HOW (the product and CTA).** Reveal exactly enough to make the click
+the obvious next move.
+
+> "Tap below to see how ____ works for ____."
+
+Note that the CTA is what satisfies `format/missing-cta`. Write it as
+a benefit the reader gets by clicking, and use an imperative verb so
+the gate can see it.
+
+## Proof, credibility, and the "So what?" chain
+
+Every claim in an ad needs support, and short-form forces that support
+to be compressed. What counts:
+
+- **Specific numbers.** "47,312 customers" over "thousands of
+  customers".
+- **Named results.** "Sarah lost 23 lbs" over "our customers love it".
+- **Timeframes.** "in 8 weeks" over "fast results".
+- **Authority.** A named publication, institution, or study.
+- **Visual proof.** Before and after, screenshots, a demo.
+- **Social proof.** User counts, review ratings, waitlist numbers.
+
+`format/missing-proof` is a crude proxy for all of this: it only looks
+for a digit or an attribution verb in primary text over 200 characters.
+Passing that check is not the same as having proof. It is the floor.
+
+The **"So what?" chain** converts a feature into the line the ad
+actually runs. Ask "so what?" until you hit something emotional or
+financial.
+
+> Feature: fast database.
+> So what? Queries return in milliseconds.
+> So what? Users stop bouncing and revenue stops leaking.
+> So what? You stop waking up at 3am worrying about churn.
+
+Three levels down is where the copy lives. Write "close your laptop at
+5pm instead of 9pm" rather than "saves 4 hours a week".
+
+## UGC and video scripts
+
+Two short-form video shapes belong in this format. Long-form video
+sales letters are a different contract; see `direct-response-copy`.
+
+**Short talking head (15 to 60 seconds).** The goal is to look and
+sound like a real person filmed it on a phone.
+
+```
+[HOOK 0-3s]      Pattern interrupt, question, or bold claim.
+                 VISUAL: talking to camera, casual setting.
+[PROBLEM 3-10s]  Name the pain specifically enough that they nod.
+                 VISUAL: relatable scenario.
+[MECHANISM 10-25s] Tease the discovery, explain just enough.
+                 VISUAL: showing or demonstrating the product.
+[RESULT 25-40s]  A specific transformation with numbers.
+                 VISUAL: the result, genuine reaction.
+[CTA 40-60s]     Natural close that sounds like a recommendation.
+                 VISUAL: direct to camera.
+```
+
+**Story-style video (60 to 120 seconds).** A personal narrative arc,
+strongest in emotional markets. Open in the middle of the struggle
+("Six months ago I couldn't look at myself in the mirror"), move
+through failed attempts, then the turning point, then a transformation
+with real numbers and a real timeline, then close on a recommendation
+rather than a pitch.
+
+Voice rules for both: first person and conversational, occasional
+verbal filler ("honestly", "I mean") for authenticity, concrete details
+over vague claims, and a CTA that sounds like advice to a friend. Mark
+on-screen action with `[VISUAL]` notes.
+
+The authenticity test before delivering any script: would a real person
+say this out loud, on camera, to their own phone? If it sounds like a
+copywriter wrote it, rewrite it. A UGC script should read slightly
+imperfect, because that is what makes it believable.
+
+## Testing and variation
+
+Any ad request should produce three to five variations, each labelled
+with its angle, because the point of an ad is to find out which angle
+wins rather than to guess correctly the first time. The default set:
+
+```
+## Variation 1: curiosity hook
+### Primary text
+### Headline
+### Description
+
+## Variation 2: contrarian hook
+...
+
+## Variation 3: social proof hook
+...
+```
+
+Run the gate on each variation file. A variation that fails on a
+headline length or an unqualified claim is not a variation, it is a
+rejected ad.
+
+Test in order of impact: hooks first (the same ad body with five to ten
+different openings), then images and thumbnails, then caption length
+(short click-sellers against long story-sellers), then video length,
+then the copy angle. The pattern that works: a control creative runs
+continuously while new hooks are tested against it, and a hook that
+wins becomes the new control.
+
+## Voice and anti-patterns
+
+The universal contracts already ban the AI vocabulary, so read
+`tells-detector` for that list. The ad-specific additions:
+
+**Ad clichés to cut.** "Click the link in my bio", "you won't
+believe", "take your X to the next level", "are you ready to".
+
+**Hedging verbs.** Clayton Makepeace's rule: can, could, should, might,
+may, ought to. Say what the product will do. Stacking two of them fires
+`tells/hedge-stack` as an error anyway.
+
+**Structural tells.** Every sentence the same length, every bullet
+opening the same way, grammar so clean it reads as written rather than
+spoken, and too many headings for the length. `prose/low-burstiness`
+catches the first of these mechanically.
+
+**Readability.** Aim low. Short sentences, plain words. The universal
+contract's grade ceiling is 10; good ad copy usually lands well under
+it.
+
+Read the ad aloud before delivering it. Makepeace's tingle factor: the
+chain from the first line to the click breaks wherever the reader gets
+bored, stops believing you, or loses the thread. Where the reading goes
+flat is where you rewrite.
+
+Last pass before delivery, checking things the gate cannot see:
+
+1. Does the first line stop the scroll?
+2. Is every claim attached to a specific number or proof point?
+3. Does it sound like a person talking?
+4. Is there an open loop pulling toward the click?
+5. Is it about the reader's transformation or about your product?
+6. Does the rhythm alternate between punchy and breathing room?
+7. Is the CTA benefit-driven rather than a bare command?
+
+## When a violation looks wrong
+
+The length rules and `format/weak-headline` are close to
+unarguable, since they encode what the platform does. The judgment
+calls sit elsewhere.
+
+`format/missing-cta` matches on a verb list, so an ad whose call to
+action is phrased without one of those verbs ("Your seat is waiting")
+will fire it. That is usually the rule being right: an ad that never
+names the next step in plain words is asking the reader to infer it.
+
+`format/unqualified-claim` fires on a substantiated claim as readily as
+on a made-up one, because the regex cannot see your evidence. A real
+clinical result still gets flagged, and it still needs qualifying
+before it ships, so the fix is to add the qualification rather than to
+argue with the flag.
+
+Where a flag genuinely does not fit the brief (a B2B ad in a register
+that the general-audience reading-ease floor penalizes, or a regulated
+category whose required disclaimer language trips a prose rule), that
+is a signal the brief's register does not match this core's default
+contract. Raise it to the user per `hedgehog-copywriting-loop`'s rule
+on extending the contract, rather than working around the flag
+silently.

--- a/skills/direct-response-copy/SKILL.md
+++ b/skills/direct-response-copy/SKILL.md
@@ -1,0 +1,573 @@
+---
+name: direct-response-copy
+description: Reference for what scripts/check-copy's long-form direct-response format contract actually flags and why: missing CTA, missing specificity, vague benefit claims, missing proof, unqualified claims. Plus the headline, opening, curiosity, flow and framework craft that writing toward that contract depends on. Read this to understand a `format/*` violation before revising against it. It is not a way to hand-grade a sales page in place of running the script.
+---
+
+# Direct response copy
+
+> Adapted from the `direct-response-copy` skill by Rob Palmer
+> (https://github.com/robpalmer99/claude-code-copywriting-skills),
+> used under CC BY 4.0.
+
+`scripts/check-copy/rules/formats/direct-response.mjs` is the actual
+gate for this format. This skill explains what it checks, why each
+check exists, and what craft produces copy that clears it on the first
+pass instead of the fourth. Reading this list is never a substitute for
+running the script. A sales page ships because the process exited 0.
+An agent reading it back to itself and liking it is a different thing.
+
+Invoke the gate on this format with:
+
+```
+node scripts/check-copy/index.mjs <file> --format direct-response
+```
+
+## Scope
+
+This format covers LONG-FORM persuasive copy whose job is a measurable
+action from the reader: sales pages, VSL and TSL scripts, email copy,
+headlines, and the CTAs that close them. Two neighbours are deliberately
+out of scope. A short bridge page, where the constraint is compression
+rather than sustained persuasion, belongs to `landing-page-copy` and its
+`--format landing-page` contract. Meta ad copy, where character caps and
+platform policy do most of the enforcing, belongs to `ad-copy` and
+`--format ad`. A single post on X belongs to `tweet-copy`. Pick the
+format that matches where the copy ships, because each module checks a
+different thing.
+
+## What the gate checks
+
+Five rules fire from the direct-response module. Four are errors and one
+is a warning, which tells you what the format is strict about: making a
+specific claim, and asking for the action.
+
+- **`format/missing-cta`** (error). No call-to-action verb appears
+  anywhere in the body. The pattern looks for the verbs that actually
+  ask: click, tap, call, order, buy, get, grab, start, try, book, claim,
+  download, join, subscribe, reply, register, reserve. Direct response
+  is *defined* by asking for a specific action; copy that describes an
+  offer and then trails off is brand copy wearing a sales page's
+  clothes. Name the action.
+- **`format/missing-specificity`** (error). Copy running over 100 words
+  with no number anywhere in it: no price, no timeframe, no result, no
+  count. This is an error rather than a warning because specificity *is*
+  the discipline. Every other rule in this module can be argued against
+  from some register or another, but unquantified copy has no mechanism
+  by which it could persuade. "Cleans almost all bacteria" and "cleans
+  99.6% of bacteria" are the same claim; only one of them is believed.
+  A page with zero numbers is asserting things it never grounds, and no
+  amount of rhythm fixes that. Warning severity would let it ship.
+- **`format/vague-benefit`** (error). Nine phrases that occupy the slot
+  where a concrete outcome belongs. Four are self-flattery with no
+  referent: `best-in-class`, `world-class`, `state-of-the-art`,
+  `industry-leading`. Two duck the question of who the product is for:
+  `businesses of all sizes`, `achieve your goals`. Three are stock
+  aspiration filler: the "next level" escalator, the "potential" one
+  about to be released, and the "new heights" one about to be reached.
+  The module's `VAGUE_BENEFITS` array carries the exact patterns; read
+  it there rather than trusting this paraphrase. Each fires per
+  occurrence with a sentence-grain excerpt. These are not weak words to
+  be strengthened. They are placeholders that were never filled in, and
+  the fix is always the same shape: put the concrete outcome and the
+  number behind it into the slot.
+- **`format/missing-proof`** (warning). Copy over 150 words with no
+  testimonial, named source, quoted result, or cited study. The check
+  looks for attribution verbs (said, says, told, according to), the
+  words study, survey, customers, clients, users, or any quoted run of
+  20 or more characters. Proof carries the middle of long-form copy.
+  A specific claim with nothing behind it is still just a claim, and
+  past a certain length the reader has had time to notice. This is a
+  warning because a genuinely short offer email can be honest without a
+  testimonial block; weigh it against the brief rather than padding a
+  quote in to silence it.
+- **`format/unqualified-claim`** (error). The shared claims list, run
+  on this format because the legal exposure here is real. It fires on
+  guaranteed outcomes ("guaranteed you'll", "guarantee to"), absolute
+  risk-free promises ("100% risk-free", "completely guaranteed"),
+  "zero risk", results presented as typical, make-money-fast,
+  get-rich-quick, no-effort-required framings, cure claims ("cures
+  your", "cures any"), and specific weight-loss claims ("lose 30 lbs").
+  Ad networks suspend accounts over these and regulators fine over
+  them. Qualify the claim or cut it. Note that this same list runs on
+  `--format ad`, so a claim that fails here fails there too.
+
+## What this module deliberately does not do
+
+The universal contracts always run. `tells-detector` and
+`prose-quality` fire on direct-response copy exactly as they fire on
+everything else, and this module never relaxes them. No copy type is
+licensed to sound more like an LLM because of where it ships.
+
+That matters here more than in the other formats, because direct
+response legitimately uses devices that look like defects from a
+distance. Short punchy fragments are a rhythm tool in this tradition.
+So are repeated openers across consecutive lines. Sentence-length
+variance runs wide on purpose. The module's answer is not to loosen
+`prose/*` for this format, but to add the two checks those rules cannot
+make: whether the copy is concrete, and whether it closes.
+
+So when a genuine rhythm device trips a universal rule, that is raised
+to the user, per the closing section below. It is never silently worked
+around, and it is never used as a reason to reword until one regex
+stops matching while the underlying prose stays the same.
+
+## The core principle
+
+Good direct response sounds like a person who figured something out and
+wants to tell you about it. A marketing team sounds like something else,
+and so does a guru.
+
+Write as though you are explaining something to a smart friend who is
+skeptical but curious. Back every claim with a specific. Make the
+transformation something the reader can picture. Everything below is
+mechanics in service of that.
+
+## Headlines
+
+The headline does most of the work. Caples measured one headline
+outpulling another by 19.5x on the same product and the same offer.
+Ogilvy's number: on average five times as many people read the headline
+as read the body.
+
+**The master formula:** action verb, plus specific outcome, plus a
+timeframe or a contrast.
+
+- "Ship your startup in days, not weeks"
+- "Save 4 hours per person every single week"
+- "Build a $10K/month business in 90 days"
+
+The contrast form ("days, not weeks") builds a before and after inside
+six words.
+
+**The story headline.** Caples again, with the most famous ad headline
+ever written: "They Laughed When I Sat Down at the Piano... But When I
+Started to Play!" That is a complete story in fifteen words.
+Embarrassment, then triumph. The pattern: "They [doubted] when I
+[action]... But when I [result]..."
+
+**The specificity headline.** Ogilvy's Rolls-Royce line: "At 60 miles an
+hour, the loudest noise in this new Rolls-Royce comes from the electric
+clock." It never says "quiet car". The reader reaches that conclusion
+alone, which is why it holds. The pattern: a specific number or metric,
+plus an unexpected comparison or detail.
+
+**The question headline.** "Do You Make These Mistakes in English?" ran
+for forty years. The reader thinks "what mistakes?" and self-selects.
+The pattern: "Do you [common struggle]?" or "What if you could
+[desirable outcome]?"
+
+**The transformation headline.** "From Broke Musician to $100K/Year
+Music Teacher." Before and after in one line, with the reader placing
+themselves in the before. The pattern: "From [bad state] to [good
+state]".
+
+**Why headlines fail:** reaching for clever instead of clear; forgetting
+the reader's self-interest; vague claims where a specific belongs (this
+is what `format/vague-benefit` catches); and telling the whole story so
+that nothing is left to discover.
+
+Caples' working advice was to write at least five headlines. One of
+them will beat the others by somewhere between 2x and 10x, and it will
+not be the one you expected.
+
+## Opening lines
+
+The first sentence has exactly one job: earn the second sentence.
+
+- **Direct challenge.** "You've been using Claude wrong." Stops the
+  scroll, creates tension, self-selects readers who suspect it might be
+  true.
+- **Story.** "Last Tuesday, I opened my laptop and saw a number I
+  couldn't believe: $47,329 in one day." The reader is inside the scene
+  before noticing this is sales copy.
+- **Confession.** "I'll be honest with you. I almost gave up on this
+  business three times." Vulnerability disarms skepticism.
+- **Specific result.** "In 9 months, we did $400k+ on a vibe-coded
+  website using these exact methods." Numbers buy credibility, and the
+  reader wants the how.
+- **Question.** "Have you ever stared at a blank page, knowing you need
+  to write something that sells... and just froze?" If the question
+  matches their reality, they are already reading.
+- **The short sentence.** Sugarman's approach: "It's simple." "Here's
+  the truth." "This works." Near-zero friction to begin. They are in
+  paragraph two before deciding to be.
+
+**Openings to avoid:** the pace-of-the-modern-world scene-setter, the
+"are you ready to" question with a stock aspiration attached, the
+greeting that welcomes the reader and thanks them for arriving, the
+table of contents that announces what this article will teach, and the
+invitation to dive in. These are generic enough to head any document
+about anything, which is the problem. Several of them also trip
+`tells/banned-phrase` or `format/vague-benefit` outright, so they fail
+the gate as well as the reader.
+
+## Curiosity gaps and open loops
+
+The brain wants closure. Open a loop and the reader keeps going to close
+it.
+
+**Creating the gap.** "10 Tips for Better Writing" tells you exactly
+what you get, so there is no reason to read on. "I tested 47 headlines.
+One pattern beat everything else by 3x." raises a question the reader
+now has to answer.
+
+**Seeds of curiosity.** End paragraphs with a pull into the next one:
+"But that's not even the best part." "Here's where it gets
+interesting." "Let me explain why." "Which brings me to the real
+secret." "Now here's the thing..." Two to four per page. Every
+paragraph ending on a tease reads as a tic.
+
+**The partial reveal.** "The formula has three parts. The first one is
+obvious. The third one is counterintuitive. But the second one? That's
+where the magic happens." The reader now needs the second part
+specifically.
+
+**Closing loops.** Every loop you open must close. Tease "the one thing
+that changed everything" and never deliver it, and you have spent trust
+you will not get back. Close small loops within one to three
+paragraphs; close big ones by the end of the piece.
+
+## Flow: the slippery slide
+
+Sugarman's image: the reader should be so compelled that they cannot
+stop until they have read all of it, as if sliding down a slippery
+slide. Every element exists to deliver the next element.
+
+**Bucket brigades.** Short connectives that smooth the seam between
+paragraphs: And. So. Now. But. Look. Here's why. Truth is. Turns out.
+The result? Think about it.
+
+Without one: "Most landing pages focus on features. Benefits are what
+customers care about." With one: "Most landing pages focus on features.
+Here's the thing: benefits are what customers care about."
+
+**The stutter technique.** Repeat a word from the previous sentence in
+the first sentence of the next paragraph.
+
+> "Now we're going to look at a more sophisticated technique.
+>
+> A technique used by professional writers, but often overlooked by
+> copywriters."
+
+"Technique" bridges the gap, which is smoother than starting cold.
+
+**Short first sentences.** The opening sentence of any section should be
+almost effortless to read. "It's simple." "Here's the problem." "This
+works." Momentum builds from a standing start, so make the start easy.
+
+**Vary paragraph length.** Uniform paragraphs read as monotone. Short.
+Then a medium one that expands, adds the detail, gives the eye somewhere
+to rest. Then short again. This is also what keeps
+`prose/low-burstiness` quiet, since that rule measures the same thing
+from the other side.
+
+**Momentum killers:** jargon the reader must stop to decode; long
+paragraphs with no break; tangents off the main thread; weak
+transitions that jar; and the same sentence structure used too many
+times running.
+
+## Pain quantification
+
+Vague problems feel overwhelming. Quantified problems feel solvable, and
+a quantified problem is something the reader can weigh against a price.
+
+Do the arithmetic in front of them:
+
+> 4 hrs to set up emails + 6 hrs designing a landing page + 4 hrs to
+> handle Stripe webhooks + 2 hrs for SEO tags + ∞ hrs overthinking...
+>
+> = 22+ hours of headaches.
+>
+> There's an easier way.
+
+Seeing "22+ hours" is what lets a reader decide whether eliminating it
+is worth $99.
+
+The other approach is the scenario that makes them feel it: "Imagine
+the scene: you and your team get an urgent email, so you rapidly reply.
+But just after you hit send, your team replies as well. In the best
+case, you look disorganized. In the worst case, you contradict each
+other." They have been there. Now the problem is felt rather than
+acknowledged.
+
+## The "So what?" chain
+
+The default failure of machine-written copy is stopping at the first
+layer of benefit. "Saves time." "Increases productivity." "Helps you
+grow." All true, all inert.
+
+For every feature, ask "so what?" until you hit something emotional or
+financial:
+
+> **Feature:** Fast database.
+> *So what?*
+> **Functional:** Queries load in milliseconds.
+> *So what?*
+> **Financial:** Users don't bounce, revenue doesn't leak.
+> *So what?*
+> **Emotional:** You stop waking up stressed about churn.
+
+The bottom of the chain is where the copy lives. Not "saves 4 hours"
+but "close your laptop at 5pm instead of 9pm". Not "automates outreach"
+but "wake up to replies instead of a blank inbox". Three levels down,
+then write.
+
+## Rhythm and alternation
+
+This is where generated copy most often gives itself away. It comes out
+either all choppy fragments or all flowing paragraphs. Real writing
+alternates.
+
+Short sentence. Impact. Then a longer one that breathes, adds the
+context, and sounds like an actual person talking.
+
+Two working examples of the poles. The punchy register: "Customers do
+NOT buy code. Customers buy a life transformation." Declarative,
+repeated structure, no ornament. The conversational register: "Once
+upon a time, you had a job. You traded hours for dollars, clocked in
+and out, and waited for the weekend. Your skills were confined to a
+cubicle and your ambitions to an annual review and a 4% raise." Longer,
+built on parallel structure.
+
+Both work. The craft is knowing when to punch and when to breathe. The
+shape to repeat: hook (short, sharp), expand (breathe, add context),
+land it (a kicker that punctuates).
+
+## The founder story
+
+Almost every high-converting creator page carries a first-person story.
+The shape is humble origins, struggle, discovery, success, offer, and
+the arc underneath it is vulnerability, then credibility, then shared
+journey.
+
+When writing for a founder, get their actual story. This is not
+optional decoration. On most pages it is the single highest-trust
+element, and it cannot be invented on their behalf.
+
+## Testimonials
+
+"Great product!" carries no persuasive weight at all. Structure a
+testimonial as a miniature case study: before state, action taken,
+specific outcome, timeframe, emotional reaction.
+
+- "I shipped in 6 days as a noob coder. It would have taken me months.
+  I wanna cry 🥲"
+- "I managed to exit and sell for 5 figures in a few weeks. Best
+  investment I've made in so long."
+- "We were able to buy our first business within 4 months of joining."
+
+The specifics do all of it. "4 months" is believable. "Helped me
+succeed" is not. This is also the material that answers
+`format/missing-proof`, and it only counts if the quote is real.
+
+## Disqualification
+
+Telling some readers they are not a fit feels backwards and converts
+anyway:
+
+> You're a good fit for this if:
+> ✅ You know this is a tool, and you'll need to use it
+> ✅ You're willing to reassess your existing ideas
+>
+> You're NOT a good fit if:
+> ❌ You equate success with just buying a course
+> ❌ You're not willing to do the unsexy work required
+
+It flips the frame from "please buy" to "prove you're a fit", which is
+the velvet-rope effect. It also pre-filters the customers most likely
+to ask for a refund.
+
+## CTAs
+
+Weak CTAs command an action. Strong CTAs describe what the reader gets
+by taking it.
+
+| Weak | Strong |
+| --- | --- |
+| "Sign Up" | "Get ShipFast" |
+| "Learn More" | "See the exact template I used" |
+| "Subscribe" | "Send me the first lesson free" |
+| "Buy Now" | "Start building" |
+
+Underneath the button, add friction reducers on the pattern of risk
+reversal, then social proof, then speed: "$199 once. Join 2,600+
+marketers. 2 minutes to install."
+
+Note that both columns satisfy `format/missing-cta`, since the rule only
+asks whether an action verb is present at all. Clearing the rule is the
+floor. The right column is the job.
+
+## Internet-native voice markers
+
+Signals that a person wrote this rather than a marketing department:
+
+- Revenue transparency, meaning specific numbers a corporate reviewer
+  would soften
+- Honest limitations, naming what the product does badly
+- Strategic emoji, used sparingly and on purpose
+- In-group language, the words the audience already uses with each
+  other
+
+## The full sequence
+
+Building a complete long-form page, in order: hook (outcome headline
+with a specific number or timeframe), problem (quantify the pain),
+agitate (a scenario or story that makes it vivid), credibility (founder
+story, authority, proof numbers), solution (what it does, framed as
+transformation), proof (testimonials with specific outcomes),
+objections (an FAQ or a fit/not-fit block), offer (pricing with value
+justification), urgency (only where it is real), and a final CTA with
+friction reducers beneath it.
+
+## Video scripts
+
+When the deliverable is a VSL, TSL, or video ad that hands off to an
+editor, the format matters as much as the words. The editor is a
+creative collaborator with judgment of their own.
+
+**Deliver the voiceover as the primary artifact, with minimal
+direction.** Editors read bracketed notes as mandatory rather than
+suggestive. A script carrying [CUT TO X], [B-ROLL Y], [TRANSITION Z] on
+every line reads as a contract, so instead of cutting, the editor books
+a call to settle the directions first. The script that looks more
+thorough is the one that delays the edit. Most editors will pick better
+B-roll, transitions, music and pacing than you would have described in
+brackets anyway.
+
+**The default is voiceover only.** Plain paragraphs of what the
+narrator says, broken where they should breathe. No "Hook / Problem /
+Promise" headers inside the script itself; if those labels are needed
+at all, they go in a one-line note at the top.
+
+**Add a bracketed visual direction only when one of these is true:**
+
+- A number, claim, or quote must appear on-screen for the viewer to
+  register it (price, statistic, guarantee terms, URL)
+- A product shot, screen recording, or specific supplied asset has to
+  land at a precise moment, and the audio alone does not make that
+  obvious
+- A comedic or dramatic beat depends on visual timing: a punchline
+  reveal, a hard cut, a freeze frame
+- A piece of B-roll is non-obvious enough that the script reads
+  differently with it than without it
+
+Over-directed, which triggers a clarification meeting:
+
+> [CUT TO: extreme close-up of clock ticking] [B-ROLL: stressed man at
+> desk, papers flying] "Most people waste 4 hours every morning..."
+> [TRANSITION: hard cut to bright kitchen] [B-ROLL: woman smiling,
+> sipping coffee] "...but there's a faster way to start the day."
+
+Right amount, where the editor moves immediately:
+
+> Most people waste 4 hours every morning... but there's a faster way
+> to start the day.
+>
+> [ON-SCREEN: "4 hours = 1,460 hours/year"]
+
+The on-screen text earns its bracket because the number needs visual
+anchoring. Imagery, mood and cuts stay the editor's call.
+
+**Conventions:** voiceover as plain text with no surrounding quotes, and
+paragraph breaks where the narrator breathes. Direction cues bracketed,
+all-caps tag, one line: `[ON-SCREEN: "$47/month"]`, `[B-ROLL: founder at
+whiteboard]`, `[PRODUCT SHOT]`. A cue that needs a paragraph of
+explanation belongs in a conversation with the editor before they start,
+somewhere other than the script.
+
+If the user asks for a full shot list or a shooting script, that is a
+different deliverable from a VSL handoff. Confirm before producing one,
+because the lean voiceover-first script is usually what was wanted.
+
+## Classic frameworks
+
+**Eugene Schwartz: the five levels of awareness.** The headline and the
+approach have to match where the reader already is.
+
+1. *Unaware.* No knowledge that they have a problem. Lead with identity
+   or emotion rather than the problem itself.
+2. *Problem-aware.* They feel the problem, but do not know solutions
+   exist. Name the problem vividly, then reveal that it is solvable.
+3. *Solution-aware.* They know solutions exist but not yours. Show what
+   makes your specific mechanism different.
+4. *Product-aware.* They know your product and have not bought. Handle
+   objections, add proof, create urgency.
+5. *Most aware.* They want it and need a push. Lead with the deal.
+
+The rule that falls out: the less aware they are, the longer the copy
+has to be.
+
+**Claude Hopkins, Scientific Advertising.** Advertising is salesmanship
+in print, and the only purpose is to make sales. Reason-why copy does
+not merely claim, it explains why the product works. Specificity creates
+belief, which is why "cleans 99.6% of bacteria" beats "cleans almost all
+bacteria". Test everything with coupons, codes, and splits. Headlines
+do the heavy lifting.
+
+**David Ogilvy.** On average five times as many people read the headline
+as read the body copy. Write the way you talk, naturally. Tell the
+truth, but make the truth fascinating. Give facts, because readers
+remember facts rather than adjectives.
+
+**Gary Halbert, The Boron Letters.** Find a starving crowd first,
+because the offer matters more than the copy. Write to one person, using
+"you" and "I". Tell stories instead of pitches, since stories disarm
+skepticism. Read the copy aloud, and fix whatever comes out lumpy.
+AIDA still holds: attention, interest, desire, action.
+
+**John Caples, Tested Advertising Methods.** One headline can outpull
+another by 19.5x on an identical product and offer. Self-interest beats
+cleverness. Specifics beat generalities. Test at least five headlines,
+because one will land somewhere between 2x and 10x better than the rest.
+
+**Joseph Sugarman, the slippery slide.** Every element has one job,
+which is to get the reader into the next element. Seeds of curiosity end
+paragraphs by pulling forward. His list of psychological triggers runs
+to 31; the heaviest are honesty, proof, specificity, familiarity, and
+story. The buying environment (layout, price anchoring, logical flow, a
+clear action) is part of the copy.
+
+**Robert Collier, the six essentials of every letter.** An opening that
+grabs attention. Description or explanation. An argument for buying.
+Persuasion to buy now. A risk-free offer. A clear call to action. And
+underneath all six, the line everything else in this skill is a
+technique for: enter the conversation already taking place in the
+customer's mind.
+
+## Before you run the gate
+
+Read it aloud, then ask:
+
+1. Does this sound like a person talking, or like someone "writing
+   copy"?
+2. Would I say this to a friend?
+3. Is every claim backed by a specific number or a named proof?
+4. Does the rhythm alternate between punch and breath?
+5. Is it about the reader's transformation, or about my product?
+6. Are there open loops pulling forward, and does each one close?
+7. Does the ending carry momentum into the action?
+
+Then run the script, because that list is judgment and the script is the
+gate.
+
+## When a violation looks wrong
+
+Direct response owns devices that resemble defects. A deliberate
+fragment run trips sentence-level prose checks. A repeated opener used
+as anaphora across four lines looks like the structural monotony
+`prose/low-burstiness` exists to catch. A page-level rhythm built on
+triplets meets `tells/rule-of-three-density`.
+
+When a device is genuinely load-bearing and a universal rule fires on
+it, that is a mismatch between the brief's register and this core's
+default general-audience contract. Raise it to the user per
+`hedgehog-copywriting-loop`'s rule on extending the contract. Do not
+reword until the regex stops matching while the prose underneath is
+unchanged, and do not treat a format module as license to relax
+`tells/*` or `prose/*`, because it never does.
+
+The error-severity format rules are a different case, and none of them
+have this escape hatch. Copy with no action verb is not direct response.
+Copy with no number is not making a claim anyone can check. A vague
+benefit phrase is an empty slot. An unqualified claim is legal exposure.
+Fix those at the root.

--- a/skills/hedgehog-copywriting-loop/SKILL.md
+++ b/skills/hedgehog-copywriting-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hedgehog-copywriting-loop
-description: The operating loop for the copywriting core, start to finish — planning intake (the vendored BMAD-METHOD shelf, mined into a brief), then the draft/checkCopy()/revise cycle that gates every piece of copy on a mechanical pass, not an agent's own self-report. Invoke at the start of any copy-writing session and for "what's next." Also covers this core's own planning intake.
+description: The operating loop for the copywriting core, start to finish — planning intake (the vendored BMAD-METHOD shelf, mined into a brief), then the draft/checkCopy()/revise cycle that gates every piece of copy on a mechanical pass, not an agent's own self-report. Covers the copy types (prose, ad, landing-page, direct-response, tweet) and the format contract each one gates on. Invoke at the start of any copy-writing session and for "what's next." Also covers this core's own planning intake.
 ---
 
 # Copywriting Loop
@@ -12,6 +12,44 @@ checks (`tells-detector` and `prose-quality`'s rule sets, as code) and
 returns a structured violation report. The loop exists because an
 agent's own read of its draft ("this looks clean") is not a gate; a
 process exiting 0 or 1 is.
+
+Copy that ships into a specific medium is gated on that medium's
+contract too, named by the brief's `type:` field and covered in "Copy
+types" below.
+
+## Copy types
+
+The AI-tell and prose-quality contracts are universal: they run against
+every draft, whatever it is. What differs by copy type is the medium's
+own contract, added by `--format`:
+
+| `type:` | What the format contract adds | Reference skill |
+| --- | --- | --- |
+| `prose` (default) | nothing beyond the universal pair | — |
+| `ad` | Meta's field limits (2200 primary, 40 headline, 30 description), the 125-character "See more" fold, a required CTA, and banned compliance claims | `ad-copy` |
+| `landing-page` | a required headline and CTA, proof, 500-word ceiling, 60-word mobile paragraph ceiling | `landing-page-copy` |
+| `direct-response` | a required CTA, a required number, vague-benefit claims, proof past 150 words | `direct-response-copy` |
+| `tweet` | the 280-character limit (25,000 with `--premium`), one hashtag, engagement bait, all-caps openers | `tweet-copy` |
+
+Why these are gates rather than guidance: before the format contracts
+existed, a 446-character "tweet" carrying five hashtags, a body link and
+"RT if you agree" passed this core's gate with zero errors, and so did a
+Meta ad with an 81-character headline promising readers they would "make
+money fast with zero risk". Both are rejected outright by the platforms
+they were written for. No prose rule can see either defect, because
+nothing about the sentences themselves is wrong.
+
+Three things follow, and the loop holds to all three:
+
+- **A format contract only ever adds.** None of them relaxes a universal
+  rule, so no copy type is licensed to sound more like an LLM because of
+  where it ships.
+- **The format comes from the brief, never from the draft.** The brief is
+  read-only once the draft layer starts, so a draft that reads like a
+  landing page under a `type: tweet` brief is a mismatch to raise, not a
+  flag to switch.
+- **Dropping `--format` is not a fix.** Running a tweet through the
+  `prose` contract hides the character limit rather than meeting it.
 
 ## Phase -1: ephemeral scratch setup (before Phase 0)
 
@@ -118,25 +156,44 @@ Add-ons decision on full-stack-app).
    default, since some copywriting projects do want the visual keepsake.
 2. **Mine a draft brief** from `.hedgehog/BMAD/`: what's being written
    (the concrete piece — a landing page section, a product announcement,
-   a UI microcopy string, docs prose), the audience, and the register to
-   write in, sourced from the product brief and PR-FAQ (the closest BMAD
-   artifacts to a copy brief). `00-brief.md` itself stays this thin by
+   a UI microcopy string, docs prose), its copy type, the audience, and
+   the register to write in, sourced from the product brief and PR-FAQ
+   (the closest BMAD artifacts to a copy brief). The copy type is one of
+   the `type:` values in "Copy types" above, mined from what the piece
+   actually is: a Meta ad is `ad`, a bridge or pre-sell page is
+   `landing-page`, a sales page or VSL or email sequence is
+   `direct-response`, a single post on X is `tweet`, and an article,
+   essay, or piece of documentation is `prose`. Where the piece genuinely
+   could be two of them (a short page that might be a bridge page or a
+   full sales page), ask rather than guessing: the type decides which
+   contract the draft is gated on, so a wrong guess surfaces late, as a
+   wall of format violations against copy that was never written for
+   that medium. `00-brief.md` itself stays this thin by
    design — the root the `draft` layer works from, not a copy of BMAD's
    full archive. Where the brief/PR-FAQ leaves what/audience/register
    genuinely unresolved, ask directly — don't proceed on vagueness, and
    don't invent an audience or register that wasn't stated, mined, or
    confirmed.
-3. **Write `.hedgehog/copy/00-brief.md`** — the mined what/audience/
-   register, in plain terms. This is the root the `draft` layer's
+3. **Write `.hedgehog/copy/00-brief.md`** — the mined what/type/audience/
+   register, in plain terms. The copy type goes in as a `type:` line at
+   the start of the file, on its own line, with one of the values from
+   "Copy types" above:
+   ```
+   type: tweet
+   ```
+   The `draft` layer's verify reads that line to pick the format
+   contract, so a brief with no `type:` line is gated as `prose`. This is the root the `draft` layer's
    `copy-writer` agent works from; it draws from BMAD's archive but is
    its own file, not a pointer into `.hedgehog/BMAD/`.
 4. **Confirm & Lock** — show the mined brief back in plain terms,
    alongside which BMAD skills ran and where their output lives
    (`.hedgehog/BMAD/`), before writing anything to the build graph.
-   State plainly what happens on confirmation: *"This locks in the
-   brief, adds the `copy` intent to the build graph (`hedgehog intent
-   add`), compiles it into the two-layer chain (`hedgehog plan`), and
-   commits (`chore(planning): copy brief`). The draft layer starts right
+   Show the copy type alongside the rest, and say which format contract
+   it gates on, since that is the part the user is most likely to want
+   changed before anything is locked. State plainly what happens on
+   confirmation: *"This locks in the brief, adds the `copy` intent to the
+   build graph (`hedgehog intent add`), compiles it into the two-layer
+   chain (`hedgehog plan`), and commits (`chore(planning): copy brief`). The draft layer starts right
    after — this core's workspace is already installed, so there's no
    bootstrap step to wait on. Anything wrong or missing — say so now."*
    Wait for explicit go-ahead — a revision here is just another mining
@@ -184,9 +241,11 @@ Add-ons decision on full-stack-app).
    ```
    node scripts/check-copy/index.mjs .hedgehog/copy/final.md
    ```
-3. **Read the JSON report.** `pass: false` means at least one
-   error-severity violation fired — revise and re-run, not argue with
-   the report. `pass: true` with `warningCount > 0` is a judgment call:
+3. **Read the JSON report.** `metrics.format` confirms which contract
+   ran; if it says `prose` on a draft that was meant to be a tweet, the
+   flag was dropped and the run does not count. `pass: false` means at
+   least one error-severity violation fired — revise and re-run, not
+   argue with the report. `pass: true` with `warningCount > 0` is a judgment call:
    warnings (weasel words, passive voice, low burstiness, readability
    drift) are real signal but not automatically disqualifying — weigh
    each against the brief's register before deciding whether to revise
@@ -237,6 +296,10 @@ Add-ons decision on full-stack-app).
   "delve" from a sentence that's still structurally a hedge stack is
   gaming the gate, not fixing the copy — the loop should always leave
   the draft better, not just quieter.
+- **The format contract is not optional and not swappable.** Dropping
+  `--format`, or switching it to a type the brief didn't name, turns a
+  failing draft into a passing report without changing the copy. That is
+  the same gaming move as rewording to dodge a regex, one level up.
 - **`checkCopy()`'s default thresholds are the general-audience
   contract** (see `prose-quality`'s reading-ease floor and grade
   ceiling) — this core ships one fixed rule set, not a per-project

--- a/skills/landing-page-copy/SKILL.md
+++ b/skills/landing-page-copy/SKILL.md
@@ -1,0 +1,414 @@
+---
+name: landing-page-copy
+description: Reference for what scripts/check-copy's landing-page format contract actually flags and why: page length, headline, call to action, proof, wall-of-text paragraphs, unqualified claims. Read this to understand a `format/*` violation on a short-form bridge or pre-sell page before revising against it, not to hand-grade a draft in place of running the script.
+---
+
+# Landing page copy
+
+> Adapted from the `landing-page-copy` skill by Rob Palmer
+> (https://github.com/robpalmer99/claude-code-copywriting-skills),
+> used under CC BY 4.0.
+
+`scripts/check-copy/rules/formats/landing-page.mjs` is the actual gate
+for this format. This skill explains what that module checks, why each
+check exists, and how to write a page that clears it on the first pass
+rather than the fourth. It never substitutes for running the script.
+The gate runs like this:
+
+```
+node scripts/check-copy/index.mjs <file> --format landing-page
+```
+
+The universal contracts run underneath every format. `tells-detector`
+and `prose-quality` fire on this draft exactly as they fire on any
+other, and a format module only ever adds rules on top of them. No copy
+type is licensed to sound more like an LLM because of where it ships.
+
+## Scope
+
+This format is the short-form landing page: the bridge page or pre-sell
+page that sits between an ad and a VSL, video, quiz, or offer. Its one
+job is the clickthrough.
+
+A long-form sales page is a different animal with a different contract.
+Price, offer stack, guarantee, objection handling, and close all belong
+to `direct-response-copy` and its module,
+`scripts/check-copy/rules/formats/direct-response.mjs`. If the brief
+asks for a page that sells rather than a page that hands off, brief it
+there. The `format/page-length` warning below is the gate saying the
+same thing.
+
+The traffic arriving on this page comes from `ad-copy` and
+`scripts/check-copy/rules/formats/ad.mjs`. Read that skill alongside
+this one whenever the ad and the page are being written together,
+because message match (below) is what decides whether the click
+survives the transition.
+
+## What the gate checks
+
+- **`format/page-length`** (warning, over 500 words). A bridge page
+  that runs long has stopped being a bridge page. The reader came from
+  an ad and is deciding in seconds. The message says so directly: past
+  500 words it is a sales page and should be briefed as one, which
+  means moving it to `direct-response-copy` rather than trimming
+  arbitrarily until the number goes green.
+- **`format/missing-headline`** (error). No `# ` headline anywhere in
+  the file. The page opens with exactly one H1 carrying the promise.
+  Ogilvy's count holds: five times as many people read the headline as
+  read the body, so a page without one has no top.
+- **`format/headline-length`** (warning, over 90 characters). A
+  headline that wraps to three lines on a phone loses the scroll before
+  the promise finishes landing. Ninety characters is roughly two mobile
+  lines.
+- **`format/missing-cta`** (error). No call-to-action verb anywhere in
+  the body. The module scans for `click`, `tap`, `watch`, `get`,
+  `grab`, `start`, `try`, `book`, `claim`, `download`, `join`, `order`,
+  `continue`, `see how`, `find out`. A page missing the CTA is not a
+  weak landing page, it is not a landing page at all, which is why this
+  one is an error rather than a warning. Name the action and name where
+  it leads.
+- **`format/missing-proof`** (warning). No digit anywhere in the body
+  and no attribution verb (`said`, `says`, `told`, `according to`). A
+  number, a named source, or a timeframe is what makes the promise
+  credible. Without one the page is asking for trust it has not earned.
+- **`format/wall-of-text`** (warning, per paragraph over 60 words).
+  Mobile carries most of this traffic, and a 60-plus word paragraph is
+  a grey slab on a phone that gets skipped whatever it says. Headings
+  and table rows are exempt; every other paragraph is counted.
+- **`format/unqualified-claim`** (error, per match). The shared
+  claims check, run against the raw text. It catches guaranteed
+  outcomes ("guaranteed you'll", "guarantees to"), absolute risk-free
+  promises ("100% risk-free", "completely guaranteed"), "zero risk",
+  "results are typical", "make money fast", "get rich quick",
+  "no effort required", cure claims ("cures your", "cures all"), and
+  specific weight-loss claims ("lose 30 pounds"). Ad networks suspend
+  accounts over these, and a suspended account takes every page behind
+  it down with the ad. The fix is to qualify the claim or cut it, never
+  to reword around the pattern while keeping the promise.
+
+Two of these are errors and block the gate: `format/missing-headline`,
+`format/missing-cta`, plus every `format/unqualified-claim` match. The
+rest are warnings, real signal weighed against the brief per the
+copywriting loop's step 3.
+
+## What this page is, and is not
+
+A short bridge page. Roughly 300 to 500 words in this contract. It
+sits between the ad and the destination and hands the visitor across.
+
+It is not a sales page: no price, no offer stack, no checkout. It is
+not an advertorial: no long-form editorial. It is not a squeeze page:
+no email capture. It is not a product page: no specs, no features, no
+mention that a product is for sale at all.
+
+The visitor's mental state on arrival is specific and worth writing
+toward. They clicked an ad seconds ago. Three questions are live in
+their head: is this legitimate, is this worth my time, and what is
+this actually about? The page answers the first two with yes and keeps
+the third one open. Curiosity that resolves on the page has nowhere
+left to send them.
+
+## The three-paragraph framework
+
+Every winning bridge page carries the same three elements in the same
+order. Each can expand to two or three short paragraphs on the page
+itself, but the concepts stay fixed.
+
+### Paragraph 1: the discovery (authority plus root cause)
+
+An expert authority has found something new about the problem.
+
+What goes in it:
+
+- A named authority figure (a doctor, a scientist, a researcher) or a
+  credible institution.
+- A specific novel root cause. The symptom restated does nothing.
+- Visceral language that makes the cause feel physical and present.
+- A named mechanism that sounds proprietary and particular.
+
+The shape, in the register that works:
+
+> Researchers at a Boston university have found a toxic film that
+> forms around the pancreas in type 2 diabetics, built from clingy
+> zombie cells that shut down insulin production.
+
+> Top scientist reveals a simple 7-second "glucose flush" that helps
+> manage high blood sugar, and it has nothing to do with diet,
+> exercise, or medication.
+
+Authority plus specificity plus novelty. The reader's reaction is that
+this sounds credible and also different from everything already tried.
+Authority patterns that carry weight: a titled expert ("top doctor",
+"leading eye specialist"), a research group at a named institution, a
+named individual with geographic specificity.
+
+### Paragraph 2: social proof (results plus benefits)
+
+Real people are already getting results from this method.
+
+What goes in it:
+
+- A specific count. "257,000 people" beats "thousands of people"
+  every time, and it also satisfies `format/missing-proof`.
+- Tangible results with a timeframe attached.
+- The pain point being resolved, named in the reader's words.
+- Optionally a named testimonial with a location.
+
+> Over 257,000 people have already worked this morning habit into
+> their routine, and the test results keep coming back the same way.
+
+> Tasha Bailey from Birmingham was told there was no fix. Seven weeks
+> later her blood test levels all sit inside the normal range.
+
+Proof strength runs in a rough order. A named testimonial with a photo,
+specific results, and a location sits at the top. Below it, verified
+review screenshots, then a case study with numbers and dates, then an
+expert endorsement, then media mentions, then an aggregate user count,
+then an anonymous testimonial at the bottom. Use the strongest proof
+actually available, and match the proof type to the objection the
+reader is most likely holding.
+
+### Paragraph 3: the call to action (urgency plus direction)
+
+Clicking the button becomes the only sensible next move.
+
+What goes in it:
+
+- Direct address ("If you or anyone you care about...").
+- The problem restated, so the CTA connects back to the pain.
+- Urgency drawn from the information rather than from a price.
+- One clear action, named plainly.
+- Button text carrying the benefit.
+
+> If you or anyone you care about is dealing with high blood sugar,
+> watch this 3-minute video before it comes down.
+
+Urgency here cannot come from a discount, because nothing is for sale
+on this page. It comes from the information: the video may be pulled,
+the industry may get it removed, the reader should watch right now, the
+watch itself is short. Three minutes is a low-friction ask, and saying
+the runtime out loud lowers it further.
+
+## Message match, ad to page
+
+The page has to read as a continuation of the ad, never as a new
+experience. If the ad said "7-second morning trick", the page says
+"7-second morning trick" in the same words. Same mechanism name, same
+authority figure, same promise, ideally the same opening image. Any
+seam between the two reads as a bait-and-switch and the visitor
+bounces before the first paragraph finishes.
+
+Write the ad and the page as one unit whenever the brief allows it.
+When they were written separately, read them side by side and reconcile
+the vocabulary before either goes to the gate.
+
+## The unique mechanism
+
+The mechanism is what makes this different from everything the reader
+has already failed with. On a bridge page it gets teased, never
+explained.
+
+Build it from a proprietary name, a one-line explanation, and a reason
+it is different. Strong mechanisms share traits: credible (backed by an
+institution or a named expert), rare (newly found, hard to come by),
+small and specific (a 7-second trick beats a 20-minute routine), low
+effort, and named. "The Glucose Flush Method" works. "A healthy
+lifestyle change" does nothing.
+
+The test is substitution. Swap your mechanism name for a competitor's.
+If the page still reads fine, the mechanism carries no weight and the
+page is running on generic claims.
+
+### The mechanism tease
+
+Give enough for credibility and keep the resolution behind the click.
+Say what it is in category terms (a plant, a method, a technique). Say
+what it is not. Drop a specific hint that is vivid and unresolvable
+from the page alone: it is 150 million years old, it is smaller than a
+nickel, it grows only above 12,000 feet. The reader closes the loop by
+clicking.
+
+## The "nothing to do with" pattern
+
+Eliminating the reader's existing mental models makes the mechanism
+feel genuinely new and removes objections in the same stroke.
+
+> This has nothing to do with genetics, diet, exercise, or medication.
+
+Each eliminated option kills an objection the reader was already
+forming and deepens curiosity about what the answer actually is. Keep
+the list to three or four items. Longer runs read as filler.
+
+## Visceral language
+
+Make the problem felt rather than understood.
+
+| Clinical | Visceral |
+|---|---|
+| cellular buildup | toxic blanket |
+| dead cells | clingy zombie cells |
+| reduced insulin output | complete shutdown of insulin production |
+| affects your body | attacks your body |
+
+Reach for sensory words: slimy, clingy, burning, stabbing, crushing.
+The medical-textbook register kills a bridge page faster than a weak
+headline does.
+
+## Intrigue intensifiers
+
+Four moves that raise curiosity without adding claims.
+
+- **Say what it is not.** "It is not a diet. It is not a supplement.
+  It is not exercise or willpower."
+- **Say where it is not.** "You will not find it in a store, a
+  pharmacy, or on any website."
+- **Drop a specific hint.** "It is 150 million years old." "A Boston
+  lab announced it last week."
+- **Anchor to authority.** "Experts call it..." "Over 100 medical
+  reports now show..."
+
+## The 60-second sales hook
+
+Kevin Rogers' four-part formula, for pages that lead with a personal
+story instead of an institutional discovery.
+
+**Identity, then struggle, then discovery, then result.**
+
+> Hi, I am [name], a [age and role] from [place]. For years I fought
+> [specific problem]. Then I found [mechanism]. Now I [specific
+> result], and [life change].
+
+The rapport comes from vulnerability and from specificity together.
+A vague struggle builds nothing.
+
+## Headline formulas
+
+The headline sits above the body and sets up the three paragraphs. Keep
+it under 90 characters so `format/headline-length` stays quiet and the
+line stays readable on a phone.
+
+- **Authority plus mechanism plus benefit**: "Top doctor: do this to
+  normalize blood sugar"
+- **Percentage plus discovery**: "97% of people have never heard of
+  this A1C hack"
+- **Mechanism plus timeframe**: "Simple 7-second glucose flush helps
+  manage high blood sugar"
+- **Question**: "Can one enzyme restore normal blood sugar?"
+- **Urgency plus benefit**: "10-second cold water trick balances blood
+  sugar overnight"
+- **Story hook**: "How a 10-second method brought my wife's vision
+  back"
+
+Note the character budget. Every formula above lands well inside 90
+because the mechanism does the work rather than the adjectives.
+
+## Formatting
+
+Mobile is the primary context. Most of this traffic arrives on a phone,
+which is the reason `format/wall-of-text` is a real rule and not a
+taste preference.
+
+**Mobile first:**
+
+- Two or three sentences per paragraph, hard ceiling. Sixty words is
+  where the gate starts complaining, and the gate is generous.
+- Large type. Thumb-readable without pinching.
+- Tall, wide, high-contrast CTA buttons the thumb cannot miss.
+- Every word earns its place. Cut without mercy.
+- If a paragraph looks like a slab on a phone screen, split it.
+
+**Desktop:**
+
+- Generous paragraph spacing.
+- Bold or highlight the discovery, the numbers, and the CTA line.
+- Ample line height for scanning.
+- Color emphasis on the key claim and on the button.
+
+**CTA button text:**
+
+Benefit-forward, never generic. "Watch the free video" beats "Click
+here". "Watch video now" beats "Submit". Place it directly after the
+final paragraph, and repeat it once mid-page on anything past 400
+words. Worth testing against each other rather than settling by taste.
+
+## Angle variations from one source
+
+The fastest route to bridge page copy is extraction rather than
+invention. Pull the discovery, the mechanism, the authority figure, the
+proof numbers, and the pain points out of the offer's existing
+material, then organize them into the three-paragraph framework.
+
+Ship two or three variations testing different angles against the same
+source, and label each one so it can be tested cleanly:
+
+```
+## Variation 1: authority discovery
+
+### Headline
+[authority plus mechanism plus benefit]
+
+### Body
+[paragraph 1: discovery]
+
+[paragraph 2: proof]
+
+[paragraph 3: CTA]
+
+### CTA button text
+[button text]
+```
+
+Angles worth putting into rotation:
+
+- **Authority discovery**: open on the researcher or the institution.
+- **Proof first**: open on the number of people already getting
+  results.
+- **Story**: open on one named person's transformation.
+- **Mechanism mystery**: open on the "nothing to do with" elimination.
+- **Visceral problem**: open on a vivid picture of the root cause.
+
+Each variation is a separate file and gets its own gate run.
+
+## Voice and anti-patterns
+
+**Sounds like:** a friend urgently passing along something they just
+found out. A news report on a breakthrough. Someone genuinely excited
+about results they have watched happen. Conversational, quick, a little
+breathless.
+
+**Does not sound like:** a sales pitch (nothing is for sale here). An
+AI (see `tells-detector`). A medical textbook. Generic marketing
+uplift. Over-produced copy that opens on the state of the modern world.
+
+**Words to ban.** The AI tells are already error-severity under
+`tells/banned-word`, and that list is documented in `tells-detector`
+rather than repeated here, since writing it out would fail this very
+file. On top of it, this format has its own dead vocabulary the gate
+cannot see:
+
+- Marketing filler: "are you ready to", "take your X to the next
+  level", the fast-paced-world opener, "you won't believe".
+- Hedging verbs in the promise: can, could, should, might, may. A
+  bridge page states.
+
+**Readability.** Aim below Flesch-Kincaid grade 6 on this format, well
+under the general-audience ceiling of 10 that `prose-quality` enforces.
+Short sentences, plain words. A page a twelve-year-old would stumble
+over is a page that loses cold traffic.
+
+**The read-aloud test.** Read the draft out loud. If it sounds like
+someone telling a friend about something they just found out, it works.
+If it sounds like copy, rewrite it.
+
+## When a violation looks wrong
+
+A brief that genuinely needs more than 500 words, or a claim that
+genuinely needs the absolute phrasing the shared claims list catches,
+is a signal that the brief and this format contract are in tension. The
+usual cause is that the piece is a sales page filed under the wrong
+format, in which case `direct-response-copy` is the right home for it
+and the fix is to rebrief rather than to trim.
+
+Either way, raise it to the user per `hedgehog-copywriting-loop`'s rule
+on extending the contract. Never reword a draft purely to dodge a
+specific regex while the thing the rule flagged stays in the copy.

--- a/skills/prose-quality/SKILL.md
+++ b/skills/prose-quality/SKILL.md
@@ -58,6 +58,18 @@ reimplementation of syllable counting or sentence tokenization.
   "implement") removes the actor and adds length without adding
   meaning.
 
+## Enumeration reads better as a list
+
+No rule catches this mechanically, but it's the same family of defect
+as low-burstiness and nominalization density: a shape that reads as
+mechanical or dense even though no single sentence is wrong. A
+paragraph naming two or more things in a row ("...went out at 457
+characters... A Meta ad shipped with...") reads denser and more
+repetitive than the same content broken into a list or numbered
+points, especially once a reader is scanning rather than reading
+straight through. The gate won't fail a paragraph for this; rewrite
+toward the list anyway before presenting a draft.
+
 ## Errors vs. warnings
 
 Only `prose/repeated-word` is error-severity — an unambiguous defect.

--- a/skills/tells-detector/SKILL.md
+++ b/skills/tells-detector/SKILL.md
@@ -39,6 +39,11 @@ only past a per-document density threshold.
 - **`tells/negation-formula`** — "it's not just X, it's Y" and its
   variants. State the positive claim directly instead of setting up a
   contrast that adds no information.
+- **`tells/emphatic-fragment`** — a short standalone sentence built
+  from absolute vocabulary ("Nothing else is left behind.", "Every
+  time, not once.") that restates the previous claim instead of adding
+  to it. The tell is the terse fragment used as emphasis, not short
+  sentences in general. Cut it, or fold it into the sentence before it.
 - **`tells/hedge-stack`** — pairing two hedges ("could potentially,"
   "may eventually"). Pick one claim and state it; stacking hedges
   doesn't make an uncertain claim more honest, just softer.
@@ -46,10 +51,11 @@ only past a per-document density threshold.
   as," "represents a" substituted for plain "is/are." Named in
   Wikipedia's essay as a specific LLM tic; the dressed-up form adds
   syllables without adding meaning.
-- **`tells/em-dash-density`** — a document-level rate check (fires
-  above ~2 per 1000 words), not a per-instance ban. Em dashes have a
-  legitimate use; the tell is using them as the default connector
-  instead of a comma, period, or restructured sentence.
+- **`tells/em-dash`** — every em dash, at error severity, not a rate
+  check. A human reaching for a dash in running prose almost always
+  reaches for a hyphen or a comma, so the character itself is the tell
+  regardless of how often it appears. Use a comma, a period, or
+  parentheses.
 - **`tells/rule-of-three-density`** — a document-level check on "X, Y,
   and Z" triplet cascades. A rhythm device used once is fine; used
   as a reflex on every list, it reads templated.

--- a/skills/tweet-copy/SKILL.md
+++ b/skills/tweet-copy/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: tweet-copy
+description: Reference for what scripts/check-copy's tweet format rules actually flag and why: the 280-character platform count, hashtag piles, engagement bait, body links, weak and all-caps hooks, false contrarian frames, plus the single-post hook formulas to draft toward. Read this before revising a `format/*` violation on a post for X, not to hand-grade a draft in place of running the script.
+---
+
+# Tweet Copy
+
+> Adapted from the `x-post-writer` skill by Sergey Bulaev
+> (https://github.com/sergebulaev/x-skills), used under the MIT licence.
+
+`scripts/check-copy/rules/formats/tweet.mjs` is the actual gate. This
+skill explains what it checks and why, so a `format/*` violation on a
+post for X gets fixed at the root cause rather than trimmed just enough
+to clear a threshold. Never substitute a manual read of this list for
+running the script; the premise of this core is that the check is
+mechanical, not agent-graded.
+
+Invoke it on a file holding one draft post:
+
+```
+node scripts/check-copy/index.mjs <file> --format tweet
+node scripts/check-copy/index.mjs <file> --format tweet --premium
+```
+
+`--premium` raises the character ceiling from 280 to 25000 and changes
+nothing else. Pass it only when the author's account actually has
+Premium and the extra length earns itself.
+
+The universal contracts run underneath this one on every invocation:
+`tells-detector` for AI vocabulary and phrasing, `prose-quality` for
+readability and sentence rhythm. The tweet module only adds what those
+two cannot see, which is the platform itself. For longer pieces, the
+sibling format contracts are `ad-copy`, `landing-page-copy`, and
+`direct-response-copy`.
+
+## Scope
+
+This skill covers a single post. Threads are out of scope: no numbering
+scheme, no per-post hook chain, no continuation logic. If an idea needs
+a second post to land, that is a signal to cut it down to one claim, and
+the gate will say so through `format/tweet-length` when the draft runs
+long.
+
+The skill also ends at the draft. This core writes copy and gates it. It
+does not publish, schedule, or post anywhere, and it has no notion of a
+posting window or an approval card. What comes out is a file that
+exited 0.
+
+## What the gate checks
+
+- **`format/tweet-length`** (error). Over 280 characters, or over 25000
+  with `--premium`. The platform truncates or rejects past its limit,
+  which is a defect no amount of good writing survives. See the counting
+  rule below, because this is the one rule where the obvious mental
+  model is wrong.
+- **`format/hashtag-count`** (error). More than one hashtag. A stack
+  reads as reach-chasing to a human and X ranks it down. One is the
+  ceiling, and zero is usually right.
+- **`format/engagement-bait`** (error). "RT if you", "retweet if you",
+  "reply YES" (and its variants: reply with yep, interested, me), "like
+  if you", "follow me for more", "comment X and", "tag a friend",
+  "drop a X below". X demotes these patterns directly. They also ask for
+  a reaction instead of earning one, so the post that uses them is
+  weaker even where the ranking penalty does not apply.
+- **`format/body-link`** (warning). An external link in the post body.
+  X suppresses reach on posts that send people off-platform, so the
+  convention is to put the link in a reply and keep the post itself
+  self-contained. This is a warning rather than an error because some
+  posts genuinely are the link: an announcement whose whole payload is a
+  URL loses nothing by carrying it. That call belongs to the author, so
+  the gate reports it and passes.
+- **`format/weak-hook`** (warning). A first line running over 120
+  characters before the first line break, in a post that has a line
+  break. A multi-line post is making a promise that line one is the
+  hook; a 120-plus-character opener has stopped being a hook and become
+  the first paragraph. A single-line post never fires this rule, because
+  there is no fold to fail.
+- **`format/all-caps-hook`** (error). An opening line in all caps
+  running 15 characters or more. Intensity comes from word choice. Caps
+  are volume, and volume reads as a stranger shouting.
+- **`format/false-contrarian`** (warning). "Unpopular opinion:" in a
+  post that never names the opposing view. The rule looks for "but",
+  "however", "most people", or "everyone" somewhere in the body as
+  evidence that a popular position is actually stated. Without one of
+  those, the contrarian frame is decoration on a take nobody disputes.
+  Name what the popular position is, or drop the frame.
+
+## How X counts characters
+
+`format/tweet-length` does not measure the length of the string. It
+calls the `tweetLength` helper in `rules/formats/shared.mjs`, which
+reproduces two quirks of X's own counter:
+
+1. **Every URL costs a flat 23 characters**, however long it is. X runs
+   links through its `t.co` shortener, so a 200-character tracking URL
+   and a 12-character domain both bill 23. The helper substitutes 23
+   spaces for each `https?://…` run before counting.
+2. **Most emoji cost 2 characters.** So do CJK characters and other
+   wide-glyph ranges. The helper walks the string by code point and
+   charges 2 for anything in those ranges, 1 for everything else.
+
+Both directions matter. A draft with three emoji is 3 characters longer
+than `.length` reports, so a raw string count of 279 can be a real count
+of 282, and a draft that looked fine in an editor gets rejected at post
+time. A draft carrying a long URL runs the other way: `.length` says 340
+and the real count is 186, so a naive check would send the author off to
+cut a post that was already inside the limit. Neither error is one an
+author catches by eye, which is the reason the helper exists.
+
+## Why the first line carries the whole post
+
+A single post on X has no "see more" fold. The reader sees the opening
+line while scrolling and decides, in that line alone, whether the rest
+exists for them. Nothing arrives later to rescue an opener that only
+makes sense once line two lands.
+
+The practical test: read the first line by itself and ask whether it is
+a complete provocation. If the answer is "well, it sets up the next
+bit", rewrite it. The setup was the problem.
+
+`format/weak-hook` catches the length version of this failure. It cannot
+catch the semantic version, where a short first line is still a windup.
+That one is on the writer.
+
+## Hook formulas
+
+Seven shapes for a single post. Each skeleton is a starting frame for
+drafting rather than a template to fill mechanically. The point is to
+know which shape the idea wants before drafting, so the first line is
+chosen rather than whatever came out first.
+
+**X1, one-liner contrarian.** Best for a sharp take you can defend when
+someone argues. Aims at reposts.
+
+```
+[Widely held practice] is [the wrong thing it actually causes].
+[The one-sentence reason.]
+```
+
+The frame collapses if the take is not genuinely contested. If you would
+struggle to name someone who disagrees, the shape is wrong, and
+`format/false-contrarian` fires the moment you dress it up with
+"Unpopular opinion:".
+
+**X2, data-point hook.** Best for one odd, precise number that reframes
+something the reader thought they understood. Aims at bookmarks.
+
+```
+[Precise number with its unit and scope.]
+[What that number means, in one line.]
+[The implication for the reader.]
+```
+
+Odd precision beats round numbers. "37% of our signups never open the
+app" is a fact; "about a third" is a shrug.
+
+**X3, build-in-public confession.** Best for a real metric from your
+own work, the ugly ones included. Aims at replies, because a specific
+admission gives people something to answer.
+
+```
+[The number, stated flat, no cushioning.]
+[What I did that produced it.]
+[What I am changing.]
+```
+
+The confession has to cost something. A humble-brag in this shape reads
+as a brag with extra steps.
+
+**X4, quote post with value.** Best for adding a layer to someone
+else's take rather than restating it. Aims at reposts.
+
+```
+[The thing their post gets right, in one clause.]
+[The piece it leaves out.]
+[The concrete case where that missing piece decides the outcome.]
+```
+
+If your addition is agreement, do not post it. The value is the layer.
+
+**X5, mini-list.** Best for a scannable set of items that genuinely
+fits in one post. Aims at bookmarks.
+
+```
+[Framing line naming what the list is for.]
+
+[Item, specific]
+[Item, specific]
+[Item, specific]
+```
+
+Every item needs a specific. A list of abstractions is the shape without
+the substance, and `prose-quality` tends to catch the vagueness even
+when the format rules pass.
+
+**X6, relatable cold-open.** Best for a shared moment that needs no
+setup. Aims at likes.
+
+```
+[The moment, told in present tense, with one concrete detail.]
+[The turn or the punchline.]
+```
+
+The detail does the work. "The deploy is green and my stomach isn't"
+lands; "we've all been there" does not.
+
+**X11, third-person case study.** Best when the striking result belongs
+to someone else and the reader could plausibly copy it. Aims at reposts.
+
+```
+[Person or company] did [specific thing] and got [specific result].
+[The mechanism, in one line.]
+[Why it transfers, or where it doesn't.]
+```
+
+Use it in place of a first-person "How I" whenever the result is not
+yours. Do not invent the case, and do not round the result up.
+
+### Picking by goal
+
+| Goal | Reach for |
+|---|---|
+| Replies | X3, X1 |
+| Reposts | X1, X4, X11 |
+| Likes | X6 |
+| Bookmarks | X2, X5, X11 |
+
+Pick one goal. A post aimed at all four is aimed at none, and the shapes
+pull against each other: the confession that earns replies is a
+different opening line from the number that earns bookmarks.
+
+## Craft rules
+
+**One idea per post.** Two ideas means the second one is stealing
+attention from the first. Cut it, or keep it for another day. This is
+also the cheapest fix for `format/tweet-length`, and a better one than
+compressing two ideas into 280 characters of shorthand.
+
+**Line breaks are beats.** A break tells the reader to pause, so put one
+where a pause helps the meaning land, and nowhere else. Decorative
+breaks turn a post into a poem nobody asked for.
+
+**One specific number wherever the claim allows it.** "2.4x" beats "way
+better" because it is checkable and because it implies you measured.
+When the claim genuinely has no number, use a named entity instead: a
+tool, a company, a version. Specificity is the thing, and a number is
+the cheapest form of it.
+
+**Close on a landing.** End on the sharpest line, or on a question
+specific enough that answering it requires knowing something. "What do
+you think?" is not that question.
+
+## Anti-patterns
+
+- Padding a one-line idea with filler so it looks substantial. If the
+  idea is one line, ship one line.
+- A hashtag stack, or any hashtag doing work that a word in the sentence
+  should do.
+- More than one emoji, and any emoji at all on a serious or contrarian
+  take.
+- An all-caps opener standing in for a strong verb.
+- A rule-of-three list where the three items are abstractions. This one
+  fires in `tells-detector` as well.
+- Hard-selling the author's own product. One natural mention is the
+  ceiling.
+- Engagement bait in any of the forms the gate names, and its softer
+  cousins that the regexes do not catch. The rule is a floor.
+
+## When a violation looks wrong
+
+`format/body-link` on a post whose entire purpose is the link, or
+`format/weak-hook` on a single dense opening line that genuinely needs
+its length, are the two warnings most likely to be correct-but-wrong for
+a given brief. Both are warnings for exactly that reason, and a report
+carrying only warnings still passes the gate.
+
+The error-severity rules are different. If `format/tweet-length`,
+`format/hashtag-count`, `format/engagement-bait`, or
+`format/all-caps-hook` fires on something the brief actually calls for,
+that is a signal the brief's medium does not match this format contract:
+a post going to another platform, or copy destined for a paid placement
+where the rules differ. Raise it to the user per
+`hedgehog-copywriting-loop`'s rule on extending the contract, rather
+than working around the flag silently.

--- a/workspace/core.yaml
+++ b/workspace/core.yaml
@@ -16,5 +16,13 @@ layers:
   - id: draft
     depends_on: brief
     scope: [".hedgehog/copy/**", "scripts/check-copy/**"]
-    verify: "node scripts/check-copy/index.mjs .hedgehog/copy/final.md"
+    # The universal AI-tell and prose contracts always run. `--format`
+    # adds the contract for the medium the copy ships into, read from the
+    # brief's `type:` field by the draft layer: character limits a
+    # platform enforces, structural slots the format is defined by, and
+    # claims an ad network bans. `prose` is the default and adds none of
+    # them, which is the behaviour this core had before formats existed.
+    # See hedgehog-copywriting-loop's "Copy types" for how the field is
+    # mined and what each value gates on.
+    verify: "node scripts/check-copy/index.mjs .hedgehog/copy/final.md --format \"$(sed -n 's/^type:[[:space:]]*//p' .hedgehog/copy/00-brief.md | head -1 | tr -d '[:space:]' | grep -E '^(prose|ad|landing-page|direct-response|tweet)$' || echo prose)\""
     commit: "feat(copy): draft"

--- a/workspace/scripts/check-copy/index.mjs
+++ b/workspace/scripts/check-copy/index.mjs
@@ -5,12 +5,19 @@
 // a validated report to stdout, exit 1 if any error-severity violation
 // fired — a real gate the copy-writer loop cannot talk its way past.
 //
-// Usage: node index.mjs <file>
+// Usage: node index.mjs <file> [--format <name>] [--premium]
 //        cat draft.md | node index.mjs -
+//
+// The tells and prose contracts are universal and always run. --format
+// adds the contract for the medium the copy ships into (a character
+// limit, a required structural slot, a banned compliance claim) — checks
+// the prose rules cannot make, because nothing about the sentences
+// themselves is wrong. Defaults to `prose`, which adds nothing.
 
 import { readFile } from 'node:fs/promises';
 import { checkTells } from './rules/tells.mjs';
 import { checkProse } from './rules/prose.mjs';
+import { checkFormat, FORMAT_NAMES } from './rules/formats/index.mjs';
 import { buildReport } from './report.mjs';
 
 function countWords(text) {
@@ -30,16 +37,18 @@ async function readInput(arg) {
   return readFile(arg, 'utf8');
 }
 
-export async function checkCopy(text) {
+export async function checkCopy(text, { format = 'prose', premium = false } = {}) {
   const wordCount = countWords(text);
   const paragraphCount = countParagraphs(text);
 
   const tellViolations = checkTells(text, { wordCount });
   const { violations: proseViolations, metrics: proseMetrics } = await checkProse(text, { wordCount });
+  const formatViolations = checkFormat(text, format, { premium });
 
-  const violations = [...tellViolations, ...proseViolations];
+  const violations = [...tellViolations, ...proseViolations, ...formatViolations];
 
   return buildReport(violations, {
+    format,
     wordCount,
     paragraphCount,
     sentenceCount: proseMetrics.sentenceCount,
@@ -50,16 +59,39 @@ export async function checkCopy(text) {
   });
 }
 
+function parseArgs(argv) {
+  const options = { file: undefined, format: 'prose', premium: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--format') {
+      options.format = argv[++i];
+    } else if (arg.startsWith('--format=')) {
+      options.format = arg.slice('--format='.length);
+    } else if (arg === '--premium') {
+      options.premium = true;
+    } else if (options.file === undefined) {
+      options.file = arg;
+    }
+  }
+  return options;
+}
+
 async function main() {
-  const arg = process.argv[2];
-  const text = await readInput(arg);
+  const options = parseArgs(process.argv.slice(2));
+
+  if (!FORMAT_NAMES.includes(options.format)) {
+    process.stderr.write(`check-copy: unknown format "${options.format}" — expected one of: ${FORMAT_NAMES.join(', ')}\n`);
+    process.exit(2);
+  }
+
+  const text = await readInput(options.file);
 
   if (!text.trim()) {
     process.stderr.write('check-copy: empty input\n');
     process.exit(2);
   }
 
-  const report = await checkCopy(text);
+  const report = await checkCopy(text, { format: options.format, premium: options.premium });
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
   process.exit(report.pass ? 0 : 1);
 }

--- a/workspace/scripts/check-copy/report.mjs
+++ b/workspace/scripts/check-copy/report.mjs
@@ -27,6 +27,9 @@ export const report = z.object({
   warningCount: z.number().int().min(0),
   violations: z.array(violation),
   metrics: z.object({
+    // Which format contract ran alongside the universal tells/prose pair.
+    // `prose` is the default and adds no rules of its own.
+    format: z.string().min(1).default('prose'),
     wordCount: z.number().int().min(0),
     sentenceCount: z.number().int().min(0),
     paragraphCount: z.number().int().min(0),

--- a/workspace/scripts/check-copy/rules/formats/ad.mjs
+++ b/workspace/scripts/check-copy/rules/formats/ad.mjs
@@ -1,0 +1,147 @@
+// Format contract for a Meta (Facebook + Instagram) ad. Three fields
+// with hard platform limits, a compliance surface that can cost an ad
+// account, and one structural fact that decides whether the ad works at
+// all: the first 125 characters of primary text are the whole ad for
+// most impressions, because everything after them sits behind "See more".
+//
+// Limits come from Meta's published field specs. The visible thresholds
+// (125 primary, 27 headline) are warnings because they are display
+// truncation the writer may accept; the hard maximums (2200, 40, 30) are
+// errors because the platform rejects past them.
+//
+// A draft is expected to name its fields as markdown sections
+// ("## Headline", "## Primary text", "## Description"). A draft with no
+// sections at all is read as primary text alone, so a one-field
+// brainstorm still gets checked rather than silently passing.
+
+import {
+  parseSections, findSection, stripMarkdown, excerptAround, violation,
+  checkUnqualifiedClaims,
+} from './shared.mjs';
+
+const PRIMARY_VISIBLE = 125;
+const PRIMARY_MAX = 2200;
+const HEADLINE_VISIBLE = 27;
+const HEADLINE_MAX = 40;
+const DESCRIPTION_MAX = 30;
+
+const WEAK_HEADLINES = [
+  'learn more', 'click here', 'check this out', 'find out more',
+  'read more', 'see more', 'shop now', 'sign up', 'get started',
+  'discover more', 'act now',
+];
+
+export function checkAd(text) {
+  const violations = [];
+  const sections = parseSections(text);
+
+  const primary = findSection(sections, ['primary text', 'primary', 'body', 'ad copy']);
+  const headline = findSection(sections, ['headline', 'title']);
+  const description = findSection(sections, ['description', 'link description']);
+
+  // No named fields: treat the whole draft as primary text rather than
+  // skipping the format check entirely.
+  const primaryBody = primary ? stripMarkdown(primary.body) : (sections.size === 0 ? stripMarkdown(text) : '');
+
+  if (!primary && sections.size > 0) {
+    violations.push(violation({
+      rule: 'format/missing-field',
+      severity: 'error',
+      message: 'No primary text field — a Meta ad needs "## Primary text"; it is the field that carries the sell',
+    }));
+  }
+
+  if (primaryBody) {
+    if (primaryBody.length > PRIMARY_MAX) {
+      violations.push(violation({
+        rule: 'format/primary-text-length',
+        severity: 'error',
+        message: `Primary text is ${primaryBody.length} characters against Meta's ${PRIMARY_MAX} maximum — the platform will reject it`,
+      }));
+    }
+
+    const hook = primaryBody.slice(0, PRIMARY_VISIBLE);
+    if (primaryBody.length > PRIMARY_VISIBLE) {
+      // The fold only matters if the visible part fails to earn the click.
+      // A hook that ends mid-sentence with no open loop is the failure:
+      // the reader sees a truncated fragment and scrolls past.
+      const endsCleanly = /[.!?:]\s*$/.test(hook.trim()) || /\n/.test(hook);
+      if (!endsCleanly) {
+        violations.push(violation({
+          rule: 'format/weak-hook',
+          severity: 'warning',
+          message: `Primary text runs past the ${PRIMARY_VISIBLE}-character "See more" fold mid-thought — the first ${PRIMARY_VISIBLE} characters are the whole ad for most impressions, so land a complete hook or an open loop before the cut`,
+          excerpt: `${hook}…`,
+        }));
+      }
+    }
+
+    // The reader has to be told what to do. An ad with no imperative and
+    // no offer is a post, not an ad.
+    const hasCta = /\b(?:click|tap|get|grab|start|try|book|claim|download|watch|see|join|order|shop|learn)\b/i.test(primaryBody)
+      || (description && /\b(?:free|no credit card|instant)\b/i.test(description.body));
+    if (!hasCta) {
+      violations.push(violation({
+        rule: 'format/missing-cta',
+        severity: 'error',
+        message: 'No call to action in the primary text — name the next step the reader takes',
+      }));
+    }
+  }
+
+  if (headline) {
+    const body = stripMarkdown(headline.body) || headline.body.trim();
+    if (body.length > HEADLINE_MAX) {
+      violations.push(violation({
+        rule: 'format/headline-length',
+        severity: 'error',
+        message: `Headline is ${body.length} characters against Meta's ${HEADLINE_MAX} maximum — the platform will reject it`,
+        excerpt: body,
+      }));
+    } else if (body.length > HEADLINE_VISIBLE) {
+      violations.push(violation({
+        rule: 'format/headline-length',
+        severity: 'warning',
+        message: `Headline is ${body.length} characters; mobile truncates around ${HEADLINE_VISIBLE} — the tail will not be read`,
+        excerpt: body,
+      }));
+    }
+
+    const normalized = body.toLowerCase().replace(/[^a-z ]/g, '').trim();
+    if (WEAK_HEADLINES.includes(normalized)) {
+      violations.push(violation({
+        rule: 'format/weak-headline',
+        severity: 'error',
+        message: `Headline "${body}" is a button label, not a headline — it should be a second hook carrying a specific benefit`,
+        excerpt: body,
+      }));
+    }
+  }
+
+  if (description) {
+    const body = stripMarkdown(description.body) || description.body.trim();
+    if (body.length > DESCRIPTION_MAX) {
+      violations.push(violation({
+        rule: 'format/description-length',
+        severity: 'error',
+        message: `Description is ${body.length} characters against Meta's ${DESCRIPTION_MAX} maximum — the platform will reject it`,
+        excerpt: body,
+      }));
+    }
+  }
+
+  violations.push(...checkUnqualifiedClaims(text, 'format/unqualified-claim'));
+
+  // Proof is what separates an ad that converts from a list of adjectives.
+  // A number, a named person, or a timeframe all count.
+  const hasProof = /\d/.test(primaryBody) || /\b(?:said|says|told|according to)\b/i.test(primaryBody);
+  if (primaryBody.length > 200 && !hasProof) {
+    violations.push(violation({
+      rule: 'format/missing-proof',
+      severity: 'warning',
+      message: 'No number, named source, or timeframe anywhere in the primary text — a claim with no proof reads as an assertion',
+    }));
+  }
+
+  return violations;
+}

--- a/workspace/scripts/check-copy/rules/formats/direct-response.mjs
+++ b/workspace/scripts/check-copy/rules/formats/direct-response.mjs
@@ -1,0 +1,86 @@
+// Format contract for long-form direct response: sales pages, VSL and
+// email copy, anything whose job is a measurable action from the reader.
+//
+// This format is the loosest of the four, because the tradition it comes
+// from is deliberately varied in shape. What it is not loose about is the
+// two things every piece of direct response has to do: make a specific
+// claim, and ask for the action. Everything else here is a warning.
+//
+// Two rules run against the universal contract rather than beside it.
+// Direct response legitimately uses short punchy fragments and repeated
+// openers as rhythm, so this module never relaxes tells/prose, but it
+// does add the checks those rules cannot make: whether the copy is
+// concrete, and whether it closes.
+
+import {
+  stripMarkdown, excerptAround, violation, checkUnqualifiedClaims,
+} from './shared.mjs';
+
+const CTA_PATTERN = /\b(?:click|tap|call|order|buy|get|grab|start|try|book|claim|download|join|subscribe|reply|register|reserve)\b/i;
+
+const VAGUE_BENEFITS = [
+  [/\btake\s+(?:your|it)\s+\w+\s+to\s+the\s+next\s+level\b/gi, '"take it to the next level"'],
+  [/\bunlock\s+your\s+(?:full\s+)?potential\b/gi, '"unlock your potential"'],
+  [/\bbest[- ]in[- ]class\b/gi, '"best-in-class"'],
+  [/\bworld[- ]class\b/gi, '"world-class"'],
+  [/\bstate[- ]of[- ]the[- ]art\b/gi, '"state-of-the-art"'],
+  [/\bindustry[- ]leading\b/gi, '"industry-leading"'],
+  [/\bof\s+all\s+sizes\b/gi, '"businesses of all sizes"'],
+  [/\bachieve\s+(?:your|their)\s+goals\b/gi, '"achieve your goals"'],
+  [/\breach\s+new\s+heights\b/gi, '"reach new heights"'],
+];
+
+export function checkDirectResponse(text) {
+  const violations = [];
+  const body = stripMarkdown(text);
+  const words = body.split(/\s+/).filter(Boolean);
+
+  if (!CTA_PATTERN.test(body)) {
+    violations.push(violation({
+      rule: 'format/missing-cta',
+      severity: 'error',
+      message: 'No call to action — direct response is defined by asking for a specific action; name it',
+    }));
+  }
+
+  // Specificity is the whole discipline. Copy with no numbers anywhere is
+  // making claims it never grounds.
+  const numbers = body.match(/\b\d[\d,.]*\b/g) || [];
+  if (words.length > 100 && numbers.length === 0) {
+    violations.push(violation({
+      rule: 'format/missing-specificity',
+      severity: 'error',
+      message: 'No specific number anywhere in the copy — a price, a timeframe, a result, a count; unquantified claims are the difference between copy that converts and copy that exists',
+    }));
+  }
+
+  for (const [re, label] of VAGUE_BENEFITS) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(body)) !== null) {
+      violations.push(violation({
+        rule: 'format/vague-benefit',
+        grain: 'sentence',
+        severity: 'error',
+        message: `Vague benefit claim (${label}) — replace it with the concrete outcome and the number behind it`,
+        excerpt: excerptAround(body, match.index, match[0].length),
+      }));
+    }
+  }
+
+  // Proof carries the sale. A named source or a quoted result is what
+  // makes the specific claim believable rather than merely stated.
+  const hasProof = /\b(?:said|says|told|according to|study|survey|customers?|clients?|users?)\b/i.test(body)
+    || /["“][^"”]{20,}["”]/.test(body);
+  if (words.length > 150 && !hasProof) {
+    violations.push(violation({
+      rule: 'format/missing-proof',
+      severity: 'warning',
+      message: 'No testimonial, named source, or cited result — long-form copy needs proof carrying the middle, not just assertion',
+    }));
+  }
+
+  violations.push(...checkUnqualifiedClaims(text, 'format/unqualified-claim'));
+
+  return violations;
+}

--- a/workspace/scripts/check-copy/rules/formats/index.mjs
+++ b/workspace/scripts/check-copy/rules/formats/index.mjs
@@ -1,0 +1,31 @@
+// The format registry. `--format <name>` selects one of these; the
+// universal tells/prose contracts run regardless, and a format module
+// only ever adds rules on top of them.
+//
+// `prose` is the default and deliberately empty: a plain article, essay,
+// or piece of documentation has no medium constraint beyond the universal
+// contract, which is exactly the behaviour this core shipped with before
+// formats existed.
+
+import { checkAd } from './ad.mjs';
+import { checkLandingPage } from './landing-page.mjs';
+import { checkDirectResponse } from './direct-response.mjs';
+import { checkTweet } from './tweet.mjs';
+
+export const FORMATS = {
+  prose: { label: 'general prose', check: () => [] },
+  ad: { label: 'Meta ad copy', check: checkAd },
+  'landing-page': { label: 'short-form landing page', check: checkLandingPage },
+  'direct-response': { label: 'long-form direct response', check: checkDirectResponse },
+  tweet: { label: 'single post on X', check: checkTweet },
+};
+
+export const FORMAT_NAMES = Object.keys(FORMATS);
+
+export function checkFormat(text, format, options = {}) {
+  const entry = FORMATS[format];
+  if (!entry) {
+    throw new Error(`unknown format "${format}" — expected one of: ${FORMAT_NAMES.join(', ')}`);
+  }
+  return entry.check(text, options);
+}

--- a/workspace/scripts/check-copy/rules/formats/landing-page.mjs
+++ b/workspace/scripts/check-copy/rules/formats/landing-page.mjs
@@ -1,0 +1,94 @@
+// Format contract for a short-form landing page: a bridge or pre-sell
+// page that sits between an ad and the offer it warms traffic for. Its
+// whole job is the click through, so what this module checks is whether
+// the page is built to produce one.
+//
+// The structural spine is the three-paragraph framework the direct
+// response tradition converged on: discovery (authority and root cause),
+// proof (results), and a call to action. A page missing the CTA is not a
+// weak landing page, it is not a landing page at all, so that one is an
+// error. Mobile carries most traffic, which makes wall-of-text paragraphs
+// a real defect rather than a taste preference.
+
+import {
+  stripMarkdown, excerptAround, violation, checkUnqualifiedClaims,
+} from './shared.mjs';
+
+const MAX_PARAGRAPH_WORDS = 60;
+const MAX_WORDS = 500;
+
+const CTA_PATTERN = /\b(?:click|tap|watch|get|grab|start|try|book|claim|download|join|order|continue|see how|find out)\b/i;
+
+export function checkLandingPage(text) {
+  const violations = [];
+  const body = stripMarkdown(text);
+  const words = body.split(/\s+/).filter(Boolean);
+
+  // A bridge page that runs long has stopped being a bridge page. The
+  // reader came from an ad and is deciding in seconds.
+  if (words.length > MAX_WORDS) {
+    violations.push(violation({
+      rule: 'format/page-length',
+      severity: 'warning',
+      message: `${words.length} words — a bridge page earns the click in roughly ${MAX_WORDS} or fewer; past that it is a sales page and should be briefed as one`,
+    }));
+  }
+
+  const headlineMatch = text.match(/^#\s+(.+)$/m);
+  if (!headlineMatch) {
+    violations.push(violation({
+      rule: 'format/missing-headline',
+      severity: 'error',
+      message: 'No headline — a landing page opens with one "# " headline carrying the promise',
+    }));
+  } else if (headlineMatch[1].trim().length > 90) {
+    violations.push(violation({
+      rule: 'format/headline-length',
+      severity: 'warning',
+      message: `Headline runs ${headlineMatch[1].trim().length} characters — a headline that wraps to three lines on mobile loses the scroll`,
+      excerpt: headlineMatch[1].trim(),
+    }));
+  }
+
+  // The CTA is the entire point of the page.
+  if (!CTA_PATTERN.test(body)) {
+    violations.push(violation({
+      rule: 'format/missing-cta',
+      severity: 'error',
+      message: 'No call to action — a bridge page exists to produce a click; name the action and where it leads',
+    }));
+  }
+
+  // Proof carries the middle of the page. Without a number, a named
+  // person, or a timeframe, the page is asking for trust it has not earned.
+  const hasProof = /\d/.test(body) || /\b(?:said|says|told|according to)\b/i.test(body);
+  if (!hasProof) {
+    violations.push(violation({
+      rule: 'format/missing-proof',
+      severity: 'warning',
+      message: 'No number, named source, or timeframe on the page — the proof paragraph is what makes the promise credible',
+    }));
+  }
+
+  // Mobile is the primary context. A 60+ word paragraph is a grey slab on
+  // a phone and gets skipped whatever it says.
+  const paragraphs = body.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  for (const paragraph of paragraphs) {
+    if (paragraph.startsWith('#') || paragraph.startsWith('|')) continue;
+    const count = paragraph.split(/\s+/).filter(Boolean).length;
+    if (count > MAX_PARAGRAPH_WORDS) {
+      const index = body.indexOf(paragraph);
+      violations.push(violation({
+        rule: 'format/wall-of-text',
+        grain: 'paragraph',
+        severity: 'warning',
+        message: `Paragraph runs ${count} words; over ${MAX_PARAGRAPH_WORDS} reads as a grey slab on mobile, where most of this traffic lands — break it up`,
+        excerpt: excerptAround(body, index, Math.min(paragraph.length, 60)),
+      }));
+    }
+  }
+
+  violations.push(...checkUnqualifiedClaims(text, 'format/unqualified-claim'));
+
+  return violations;
+}

--- a/workspace/scripts/check-copy/rules/formats/shared.mjs
+++ b/workspace/scripts/check-copy/rules/formats/shared.mjs
@@ -1,0 +1,128 @@
+// Helpers shared by every format module. Format rules differ from
+// tells/prose in what they judge: not whether the writing is good, but
+// whether it obeys the medium it ships into. A character limit a platform
+// enforces, a structural slot the format is defined by, a claim an ad
+// network bans. A tweet 60% over the limit and an ad headline double
+// Meta's cap are both defects no prose rule can see, because nothing
+// about the sentences themselves is wrong.
+//
+// The universal contracts (tells, prose) always run. A format module only
+// ever adds to them, and never relaxes one: no copy type is licensed to
+// sound more like an LLM because of where it ships.
+
+// Markdown section headers split a draft into the format's named fields
+// ("## Headline", "## Primary text"). Formats that are a single block of
+// text (a tweet) ignore this; formats assembled from separate platform
+// fields (an ad) are checked field by field.
+export function parseSections(text) {
+  const sections = new Map();
+  const re = /^#{1,6}\s+(.+?)\s*$/gm;
+  const marks = [];
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    marks.push({ title: match[1].trim(), start: match.index, bodyStart: re.lastIndex });
+  }
+  for (let i = 0; i < marks.length; i++) {
+    const end = i + 1 < marks.length ? marks[i + 1].start : text.length;
+    const key = normalizeKey(marks[i].title);
+    const body = text.slice(marks[i].bodyStart, end).trim();
+    if (!sections.has(key)) sections.set(key, { title: marks[i].title, body });
+  }
+  return sections;
+}
+
+export function normalizeKey(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+// Looks up a section by any of several accepted aliases, so a draft that
+// says "## CTA" and one that says "## Call to action" both resolve.
+export function findSection(sections, aliases) {
+  for (const alias of aliases) {
+    const hit = sections.get(normalizeKey(alias));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+// Body text with markdown syntax removed: what a reader actually sees,
+// which is what a platform character limit applies to.
+export function stripMarkdown(text) {
+  return text
+    .replace(/^#{1,6}\s+.*$/gm, '')
+    .replace(/^\s*>\s?/gm, '')
+    .replace(/`{1,3}[^`]*`{1,3}/g, '')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .trim();
+}
+
+export function excerptAround(text, index, length, radius = 40) {
+  const start = Math.max(0, index - radius);
+  const end = Math.min(text.length, index + length + radius);
+  return `${start > 0 ? '…' : ''}${text.slice(start, end).trim()}${end < text.length ? '…' : ''}`;
+}
+
+export function violation({ rule, severity, message, excerpt = '', grain = 'document' }) {
+  return { rule, grain, severity, message, excerpt, location: {} };
+}
+
+// X counts a URL as a fixed 23 characters however long it really is, and
+// most emoji as 2. Counting raw string length would let a draft with
+// three long links pass at 279 here and get rejected by the platform at
+// post time, which is the failure this rule exists to prevent.
+export function tweetLength(text) {
+  const withUrls = text.replace(/https?:\/\/\S+/g, ' '.repeat(23));
+  let total = 0;
+  for (const ch of withUrls) total += isWideChar(ch) ? 2 : 1;
+  return total;
+}
+
+function isWideChar(ch) {
+  const cp = ch.codePointAt(0);
+  if (cp < 0x1100) return false;
+  return cp <= 0x115f
+    || (cp >= 0x2e80 && cp <= 0xa4cf)
+    || (cp >= 0xac00 && cp <= 0xd7a3)
+    || (cp >= 0xf900 && cp <= 0xfaff)
+    || (cp >= 0xfe30 && cp <= 0xfe6f)
+    || (cp >= 0xff00 && cp <= 0xff60)
+    || (cp >= 0x1f000 && cp <= 0x1faff)
+    || (cp >= 0x2600 && cp <= 0x27bf);
+}
+
+// Claims an ad network can suspend an account over: guaranteed outcomes,
+// risk-free promises, and income or health results presented as typical.
+// Checked on ad and direct-response copy, where the legal exposure is
+// real, rather than globally: the same sentence in an essay about
+// advertising is reporting a claim, not making one.
+export const UNQUALIFIED_CLAIMS = [
+  [/\bguarantee(?:d|s)?\s+(?:you'?ll|you\s+will|to)\b/gi, 'guaranteed outcome'],
+  [/\b(?:100%|completely|totally)\s+(?:risk[- ]free|guaranteed)\b/gi, 'absolute risk-free promise'],
+  [/\bzero\s+risk\b/gi, 'zero-risk promise'],
+  [/\bresults?\s+(?:are|is)\s+typical\b/gi, 'results presented as typical'],
+  [/\bmake\s+money\s+fast\b/gi, 'fast-money claim'],
+  [/\bget\s+rich\s+quick\b/gi, 'get-rich-quick claim'],
+  [/\bno\s+(?:effort|work)\s+(?:required|needed)\b/gi, 'effortless-outcome claim'],
+  [/\bcures?\s+(?:your|his|her|their|any|all)\b/gi, 'cure claim'],
+  [/\blose\s+\d+\s*(?:lbs?|pounds|kg|kilos)\b/gi, 'specific weight-loss claim'],
+];
+
+export function checkUnqualifiedClaims(text, ruleName) {
+  const violations = [];
+  for (const [re, label] of UNQUALIFIED_CLAIMS) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(text)) !== null) {
+      violations.push(violation({
+        rule: ruleName,
+        grain: 'sentence',
+        severity: 'error',
+        message: `Unqualified ${label} ("${match[0].trim()}") — ad networks suspend accounts over this; qualify it or cut it`,
+        excerpt: excerptAround(text, match.index, match[0].length),
+      }));
+    }
+  }
+  return violations;
+}

--- a/workspace/scripts/check-copy/rules/formats/tweet.mjs
+++ b/workspace/scripts/check-copy/rules/formats/tweet.mjs
@@ -1,0 +1,110 @@
+// Format contract for a single post on X. What the universal rules can't
+// see: the 280-character limit the platform actually enforces, and the
+// engagement patterns that suppress reach rather than earn it.
+//
+// Length is an error because the platform rejects or truncates past it,
+// which is a defect no amount of good writing survives. The rest are the
+// shapes that mark a post as manufactured: hashtag piles, "RT if you
+// agree", a bare link in the body that costs the post reach.
+
+import {
+  stripMarkdown, excerptAround, violation, tweetLength,
+} from './shared.mjs';
+
+const STANDARD_LIMIT = 280;
+const PREMIUM_LIMIT = 25000;
+
+const ENGAGEMENT_BAIT = [
+  [/\bRT\s+if\s+you\b/gi, '"RT if you…"'],
+  [/\bretweet\s+if\s+you\b/gi, '"retweet if you…"'],
+  [/\breply\s+(?:with\s+)?["']?(?:yes|yep|interested|me)["']?\b/gi, '"reply YES"'],
+  [/\blike\s+(?:this\s+)?if\s+you\b/gi, '"like if you…"'],
+  [/\bfollow\s+(?:me\s+)?for\s+more\b/gi, '"follow me for more"'],
+  [/\bcomment\s+["']?\w+["']?\s+(?:below\s+)?(?:and|to get|for)\b/gi, '"comment X and I\'ll send…"'],
+  [/\btag\s+(?:someone|a friend)\b/gi, '"tag a friend"'],
+  [/\bdrop\s+a\s+["']?\w+["']?\s+(?:below|if)\b/gi, '"drop a X below"'],
+];
+
+export function checkTweet(text, { premium = false } = {}) {
+  const violations = [];
+  const body = stripMarkdown(text);
+  const limit = premium ? PREMIUM_LIMIT : STANDARD_LIMIT;
+  const length = tweetLength(body);
+
+  if (length > limit) {
+    violations.push(violation({
+      rule: 'format/tweet-length',
+      severity: 'error',
+      message: `Post is ${length} characters against a ${limit} limit${premium ? ' (Premium)' : ''} — tighten it or split it into a thread, never ship a thought the platform will truncate`,
+    }));
+  }
+
+  const hashtags = body.match(/(?:^|\s)#[a-z0-9_]+/gi) || [];
+  if (hashtags.length > 1) {
+    violations.push(violation({
+      rule: 'format/hashtag-count',
+      severity: 'error',
+      message: `${hashtags.length} hashtags (${hashtags.map((h) => h.trim()).join(' ')}) — one at most; a stack reads as reach-chasing and X ranks it down`,
+    }));
+  }
+
+  for (const [re, label] of ENGAGEMENT_BAIT) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(body)) !== null) {
+      violations.push(violation({
+        rule: 'format/engagement-bait',
+        grain: 'sentence',
+        severity: 'error',
+        message: `Engagement bait (${label}) — X demotes it, and it asks for a reaction instead of earning one`,
+        excerpt: excerptAround(body, match.index, match[0].length),
+      }));
+    }
+  }
+
+  // A link in the body costs reach on X. The convention is to put it in a
+  // reply, so this is a warning rather than an error: some posts genuinely
+  // are the link, and that's the author's call to make.
+  const links = body.match(/https?:\/\/\S+/g) || [];
+  if (links.length > 0) {
+    violations.push(violation({
+      rule: 'format/body-link',
+      severity: 'warning',
+      message: `External link in the post body (${links[0]}) — X suppresses reach on posts that send people off-platform; put it in a reply instead`,
+    }));
+  }
+
+  // The first line does the whole job on X, which has no "see more" fold
+  // on a single post. An opener that only makes sense once you've read
+  // line two has already lost the scroll.
+  const firstLine = body.split('\n').map((l) => l.trim()).filter(Boolean)[0] || '';
+  if (firstLine && tweetLength(firstLine) > 120 && body.includes('\n')) {
+    violations.push(violation({
+      rule: 'format/weak-hook',
+      severity: 'warning',
+      message: `First line runs ${tweetLength(firstLine)} characters before the first break — the opener carries the whole post on X, so front-load the claim`,
+      excerpt: firstLine.slice(0, 80),
+    }));
+  }
+
+  if (/^[A-Z][A-Z\s!?.,'"-]{14,}$/m.test(firstLine)) {
+    violations.push(violation({
+      rule: 'format/all-caps-hook',
+      severity: 'error',
+      message: 'All-caps opening line — carry intensity with word choice, not shouting',
+      excerpt: firstLine.slice(0, 80),
+    }));
+  }
+
+  // "Unpopular opinion:" on a take nobody disputes is the tell that the
+  // contrarian frame is decoration rather than a real position.
+  if (/\bunpopular opinion\b/i.test(body) && !/\b(?:but|however|most people|everyone)\b/i.test(body)) {
+    violations.push(violation({
+      rule: 'format/false-contrarian',
+      severity: 'warning',
+      message: '"Unpopular opinion:" without a stated opposing view — either name what the popular position actually is, or drop the frame',
+    }));
+  }
+
+  return violations;
+}

--- a/workspace/scripts/check-copy/rules/prose.mjs
+++ b/workspace/scripts/check-copy/rules/prose.mjs
@@ -8,6 +8,15 @@
 // angles (retext-passive: grammatical pattern; write-good: phrase-level
 // heuristic) — both run, deduped by overlapping character offset so a
 // single passive clause isn't reported twice.
+//
+// Deliberately NOT a rule here: "a paragraph enumerating 2+ things reads
+// better as a list" (see prose-quality's "Enumeration reads better as a
+// list"). What distinguishes real enumeration from ordinary consecutive
+// sentences (cause/effect, elaboration, single-subject continuation) is
+// that a noun names a different member of the same set each time — a
+// semantic judgment, not a syntactic one, and outside what this file's
+// pattern-based rules can reliably make. Left as craft guidance, not a
+// gate.
 
 import { unified } from 'unified';
 import retextEnglish from 'retext-english';

--- a/workspace/scripts/check-copy/test/formats.test.mjs
+++ b/workspace/scripts/check-copy/test/formats.test.mjs
@@ -1,0 +1,224 @@
+// Format-contract tests. The point of every one of these is the pair:
+// copy that violates its medium must fail, and good copy in the same
+// medium must pass. A rule that only ever fires, or never fires, is not
+// a gate.
+//
+// The two "regression" tests at the top pin the exact hole these rules
+// were written to close: before formats existed, both of these drafts
+// passed the universal contract with zero errors.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkCopy } from '../index.mjs';
+
+const rules = (report) => report.violations.map((v) => v.rule);
+
+test('regression: an over-limit, hashtag-stuffed, bait-filled post passes prose but fails the tweet contract', async () => {
+  const text = `Unpopular opinion: most founders are building the wrong thing.
+
+I talked to a lot of founders this year and the pattern was clear. They build features nobody asked for, they ignore their existing users, and they chase competitors instead of customers.
+
+If you want to win, listen to your users. Simple as that.
+
+RT if you agree. Follow me for more startup insights.
+
+https://example.com/my-newsletter
+
+#startups #founders #buildinpublic #saas #entrepreneur`;
+
+  const asProse = await checkCopy(text);
+  assert.equal(asProse.pass, true, 'the universal contract alone cannot see a format violation');
+
+  const asTweet = await checkCopy(text, { format: 'tweet' });
+  assert.equal(asTweet.pass, false);
+  assert.ok(rules(asTweet).includes('format/tweet-length'));
+  assert.ok(rules(asTweet).includes('format/hashtag-count'));
+  assert.ok(rules(asTweet).includes('format/engagement-bait'));
+});
+
+test('regression: a non-compliant ad passes prose but fails the ad contract', async () => {
+  const text = `## Headline
+
+The Absolute Best Solution For Every Single Business Owner Who Wants More Revenue
+
+## Primary text
+
+Are you tired of struggling with your marketing? Our platform helps businesses of all sizes achieve their goals. We guarantee you will make money fast with zero risk. Results are typical for everyone who signs up today.
+
+## Description
+
+Sign up now and transform your business forever.`;
+
+  const asProse = await checkCopy(text);
+  assert.equal(asProse.pass, true, 'the universal contract alone cannot see a compliance violation');
+
+  const asAd = await checkCopy(text, { format: 'ad' });
+  assert.equal(asAd.pass, false);
+  assert.ok(rules(asAd).includes('format/headline-length'));
+  assert.ok(rules(asAd).includes('format/description-length'));
+  assert.ok(rules(asAd).includes('format/unqualified-claim'));
+});
+
+test('a post inside the limit with one idea and a real number passes', async () => {
+  const text = `Most teams ship a redesign and watch signups drop 12%.
+
+We did too. Turned out the new hero buried the price below the fold.
+
+Moved it up. Signups came back in four days.`;
+  const report = await checkCopy(text, { format: 'tweet' });
+  assert.equal(report.pass, true);
+  assert.equal(report.errorCount, 0);
+});
+
+test('tweet length counts a URL as 23 characters, not its real length', async () => {
+  const shortUrl = `Here is the writeup on why the redesign failed and what we changed: https://a.co/x`;
+  const longUrl = `Here is the writeup on why the redesign failed and what we changed: https://example.com/${'y'.repeat(400)}`;
+
+  const a = await checkCopy(shortUrl, { format: 'tweet' });
+  const b = await checkCopy(longUrl, { format: 'tweet' });
+  assert.ok(!rules(a).includes('format/tweet-length'));
+  assert.ok(!rules(b).includes('format/tweet-length'), 'a 400-character URL still counts as 23');
+});
+
+test('premium raises the tweet ceiling', async () => {
+  const text = `A. ${'word '.repeat(120)}`;
+  const standard = await checkCopy(text, { format: 'tweet' });
+  const premium = await checkCopy(text, { format: 'tweet', premium: true });
+  assert.ok(rules(standard).includes('format/tweet-length'));
+  assert.ok(!rules(premium).includes('format/tweet-length'));
+});
+
+test('an all-caps opening line fails the tweet contract', async () => {
+  const text = `THIS CHANGES ABSOLUTELY EVERYTHING FOR YOU
+
+We cut onboarding from 9 steps to 3. Activation went up 22%.`;
+  const report = await checkCopy(text, { format: 'tweet' });
+  assert.ok(rules(report).includes('format/all-caps-hook'));
+});
+
+test('a button label in the headline slot fails the ad contract', async () => {
+  const text = `## Headline
+
+Learn more
+
+## Primary text
+
+We audited 212 landing pages last quarter. The ones that converted shared one trait: the price sat above the fold. Click below to get the 4-point checklist we used.`;
+  const report = await checkCopy(text, { format: 'ad' });
+  assert.ok(rules(report).includes('format/weak-headline'));
+});
+
+test('an ad with real fields, a number, and a call to action passes', async () => {
+  const text = `## Headline
+
+23 lbs in 8 weeks
+
+## Primary text
+
+We audited 212 landing pages last quarter. The ones that converted shared one trait: the price sat above the fold, not below it.
+
+Sarah moved one button and watched her clickthrough go from 3% to 11% in nine days. No redesign. No new copy.
+
+Get the 4-point checklist we used.
+
+## Description
+
+Free, 2-minute read`;
+  const report = await checkCopy(text, { format: 'ad' });
+  assert.equal(report.errorCount, 0, JSON.stringify(report.violations, null, 2));
+});
+
+test('a landing page with no call to action fails, and gains a pass once it has one', async () => {
+  const without = `# The 4-minute fix for a lander that leaks
+
+You spent $8,000 on traffic last month. 94% of it left without acting.
+
+Sarah moved one button. Her rate went from 3% to 11% in nine days.`;
+  const failing = await checkCopy(without, { format: 'landing-page' });
+  assert.equal(failing.pass, false);
+  assert.ok(rules(failing).includes('format/missing-cta'));
+
+  const withCta = `${without}\n\nGet the free checklist below.`;
+  const passing = await checkCopy(withCta, { format: 'landing-page' });
+  assert.equal(passing.errorCount, 0, JSON.stringify(passing.violations, null, 2));
+});
+
+test('a 60+ word paragraph on a landing page flags as a wall of text', async () => {
+  const slab = `The ${'reason this happens on almost every page we audit is that the team writing the copy is not the team watching the analytics, and so the price ends up below the fold where nobody scrolls to find it, which means the visitor leaves before they ever see the one number that would have made the decision easy for them to make'}.`;
+  const text = `# Why your page leaks\n\n${slab}\n\nClick below to get the checklist. 212 pages audited.`;
+  const report = await checkCopy(text, { format: 'landing-page' });
+  assert.ok(rules(report).includes('format/wall-of-text'));
+});
+
+test('direct response fails on vague benefit claims', async () => {
+  const text = `Our platform is best-in-class and helps businesses of all sizes achieve their goals.
+
+We use industry-leading technology to take your operation to the next level.
+
+Sign up today. 400 teams already have.`;
+  const report = await checkCopy(text, { format: 'direct-response' });
+  assert.equal(report.pass, false);
+  assert.ok(rules(report).includes('format/vague-benefit'));
+});
+
+// The specificity rule only applies past 100 words, since a short piece
+// can carry its claim without a number. This sample clears that gate on
+// purpose: shorter copy would pass for the wrong reason.
+test('direct response over 100 words fails when no number appears anywhere', async () => {
+  const text = `Our service was built for the kind of team that has outgrown spreadsheets but has not yet found something better to replace them with.
+
+We know how that feels because we lived it ourselves for years before we started building. Every week another handoff would go missing and nobody could say quite where it went or who was holding it.
+
+So we built something different. It watches the places where work changes hands and it tells you when something has been sitting too long without moving forward.
+
+Our customers tell us it has changed how their weeks feel.
+
+Sign up today and see for yourself.`;
+  const report = await checkCopy(text, { format: 'direct-response' });
+  assert.ok(report.metrics.wordCount > 100, 'sample must clear the rule\'s word-count gate');
+  assert.equal(report.pass, false);
+  assert.ok(rules(report).includes('format/missing-specificity'));
+});
+
+test('direct response passes on specific, proof-carrying copy with a clear ask', async () => {
+  const text = `# The checklist that found $8,000 of leaked ad spend
+
+Last quarter we audited 212 landing pages for 14 clients.
+
+The pages that converted shared one trait. The price sat above the fold.
+
+Sarah runs a 3-person agency in Leeds. She moved one button on her main lander. Her clickthrough went from 3% to 11% in nine days. No redesign, no new copy, no extra spend.
+
+"I thought we had a traffic problem," she told us. "We had a layout problem."
+
+The checklist is 4 points long and takes about 4 minutes to run against a page.
+
+Get it below.`;
+  const report = await checkCopy(text, { format: 'direct-response' });
+  assert.equal(report.errorCount, 0, JSON.stringify(report.violations, null, 2));
+});
+
+test('the format contract never relaxes the universal one', async () => {
+  const text = `Our tool is not just a platform, it's a comprehensive solution that will leverage cutting-edge technology.
+
+Click below to get started. 212 teams already did.`;
+  for (const format of ['prose', 'ad', 'landing-page', 'direct-response', 'tweet']) {
+    const report = await checkCopy(text, { format });
+    assert.ok(rules(report).includes('tells/banned-word'), `${format} must still run the tells contract`);
+    assert.ok(rules(report).includes('tells/negation-formula'), `${format} must still run the tells contract`);
+  }
+});
+
+test('the default format adds nothing, and is recorded in the report metrics', async () => {
+  const text = `Every handoff between Slack and your ticket tracker drops something. A decision made in chat never makes it into the ticket. We built a single feed that both tools write to.`;
+  const report = await checkCopy(text);
+  assert.equal(report.metrics.format, 'prose');
+  assert.equal(report.violations.filter((v) => v.rule.startsWith('format/')).length, 0);
+
+  const tagged = await checkCopy(text, { format: 'tweet' });
+  assert.equal(tagged.metrics.format, 'tweet');
+});
+
+test('an unknown format is rejected rather than silently skipped', async () => {
+  await assert.rejects(() => checkCopy('some copy', { format: 'billboard' }), /unknown format/);
+});


### PR DESCRIPTION
## Summary

- Extends the copywriting core beyond universal prose to four copy types (`ad`, `landing-page`, `direct-response`, `tweet`), each with its own mechanical format contract in `rules/formats/`, selected via a new `--format` flag on the gate (default `prose`, unchanged from prior behavior).
- Adds one reference skill per type (`ad-copy`, `landing-page-copy`, `direct-response-copy`, `tweet-copy`), adapted from Rob Palmer's copywriting skills (CC BY 4.0) and Sergey Bulaev's `x-post-writer` (MIT), stripped of ecosystem dependencies this repo doesn't have and made self-contained.
- Wires the copy type through the brief (`type:` field), the `copy-writer` agent, and `core.yaml`'s draft-layer verify.
- Fixes two pre-existing doc/code drifts in `tells-detector` (a renamed rule, a missing rule) found while cross-checking the new skills against their gates.
- Adds craft guidance (not a gate rule) on enumeration-as-list to `prose-quality`, with a note in `prose.mjs` on why a mechanical version was tried and rejected — the syntactic signal that looked promising false-positived on cause/effect and elaboration as often as it caught real enumeration.

## Why

The universal AI-tell/prose-quality contract judges writing quality but not whether copy obeys the medium it ships into. Verified before building: a 446-character "tweet" stuffed with five hashtags, a body link, and "RT if you agree" passed the gate with zero errors, and so did a Meta ad with an 81-character headline (Meta's limit is 40) promising "make money fast with zero risk" — a claim that gets ad accounts suspended. Neither defect is visible to a rule about sentences. The two regression tests in `test/formats.test.mjs` pin this exact hole.

## Test plan

- [x] `npm test` — 27/27 passing (11 pre-existing + 16 new format tests)
- [x] Regression tests confirm the bad tweet/ad pass `prose` and fail their format
- [x] Every `format/*` rule the code emits is documented by exact name in its skill; no invented rules, no dead references to the source skills' ecosystem (Publora, `x-thread-builder`, missing reference files)
- [x] All four new skills pass the gate against their own prose (`errorCount: 0`)
- [x] End-to-end smoke test: ran the full loop (brief → draft → gate) once per copy type against a real target (this repo), producing passing output for each
- [x] Confirmed `type:`-less briefs still resolve to `prose` with no added rules (no behavior change for existing prose projects)