### PR TITLE
fix(loop): stop full-shelf intake at bmad-prfaq, drop bmad-prd claim

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog-core-copywriting-prose-engineering",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Hedgehog's copywriting core: a mechanical checkCopy() gate against AI-tell and prose-quality contracts, the tells-detector and prose-quality skills that define them, and the copy-writer loop that drafts against the gate until it passes.",
   "type": "module",
   "scripts": {

--- a/skills/hedgehog-copywriting-loop/SKILL.md
+++ b/skills/hedgehog-copywriting-loop/SKILL.md
@@ -132,22 +132,19 @@ Add-ons decision on full-stack-app).
    compressed intake depending on which `planner` routed to for this
    request (see that skill's "Compressed intake" section): state the
    BMAD attribution it states, then either run `bmad-forge-idea`,
-   `bmad-brainstorming`, `bmad-product-brief`, `bmad-prfaq`, `bmad-prd`,
-   `bmad-ux`, `bmad-deep-recon` in full, or — on an explicit "just build
-   it" choice, for a short, low-stakes piece — the batched round
+   `bmad-brainstorming`, `bmad-product-brief`, `bmad-prfaq` in full,
+   stopping there per that skill's "Full-shelf carve-out on
+   copywriting" (running `bmad-deep-recon` too where the piece
+   genuinely needs market/competitive/user-voice research, and never
+   running `bmad-prd` or `bmad-ux` — this core has no module axis and
+   no UI surface for either to attach to), or — on an explicit "just
+   build it" choice, for a short, low-stakes piece — the batched round
    compressed intake defines instead. Either way, archived to
    `.hedgehog/BMAD/` with the fixed layout and `00-manifest.md`
    attribution header that skill's Phase 0 defines. `.hedgehog/BMAD/` is
    archival and immutable once written, same as every other core —
    nothing in this core's day-to-day loop reads it live after this step
-   mines it once. On a full run, `bmad-ux`'s design-handoff output isn't
-   this core's primary input — `bmad-prd` and `bmad-prfaq` are — so
-   skipping `DESIGN.md` entirely and reducing `EXPERIENCE.md` to
-   whatever sections the brief actually gives it something to say about
-   (rarely more than a Key Flow, if any) is sanctioned behavior on this
-   core, not an improvisation to justify each time `bmad-ux` runs: this
-   core has no UI surface for that skill's Foundation/Component
-   Patterns/State Patterns spine to describe. `bmad-brainstorming`'s
+   mines it once. `bmad-brainstorming`'s
    Ideate-for-me mode defaults to auto-generating an HTML keepsake —
    unwanted work on a core whose deliverables are plain prose. A project
    that wants brainstorming sessions to stay markdown-only can set


### PR DESCRIPTION
## Why

- `hedgehog-copywriting-loop`'s step 1 (its planning-intake section) listed `bmad-prd` and `bmad-ux` as part of the full shelf this core runs on a first pass, then claimed `bmad-prd` was one of this core's primary inputs alongside `bmad-prfaq`.
- That claim is wrong: this skill's own step 2 mines only the product brief and PR-FAQ, and `hedgehog-planning-intake`'s compressed-intake note already states "copywriting's mining draws from those two, never `04-prd.md`."
- `hedgehog/pull/403` (companion fix, merged) added a "Full-shelf carve-out on copywriting" section to `hedgehog-planning-intake`'s Phase 0: full-shelf runs on this core stop after `bmad-prfaq` (optionally `bmad-deep-recon`), never running `bmad-prd`/`bmad-ux`.

Fixes skyf0xx/hedgehog#401 (companion side).

## What

- Step 1 now points at that carve-out instead of listing all 7 BMAD skills and re-deriving which ones matter.
- Removed the incorrect "`bmad-prd` and `bmad-prfaq` are [primary inputs]" claim and the now-redundant `bmad-ux`/`DESIGN.md`/`EXPERIENCE.md` scoping paragraph — that scoping no longer applies since `bmad-ux` never runs on this core at all.
- Bumped package version 0.2.0 → 0.2.1 via `npm run release` (patch — skill content fix, no interface change). Local tag from `npm version` was deleted before pushing; `publish.yml` tags from `master` post-merge to avoid double-tagging.

## Test plan

- [x] `grep -n "bmad-ux\|bmad-prd\|DESIGN.md\|EXPERIENCE.md\|04-prd\|05-ux-spec" skills/hedgehog-copywriting-loop/SKILL.md` — only one remaining reference, in the corrected sentence.
- [ ] CI on this PR.